### PR TITLE
Allow user to set header title in ILAMB config file

### DIFF
--- a/permafrost_benchmark_system/data/header.cfg.tmpl
+++ b/permafrost_benchmark_system/data/header.cfg.tmpl
@@ -1,4 +1,0 @@
-# Benchmark CMIP5-compatible model outputs against all available benchmarks.
-
-[h1: Permafrost Benchmark System]
-bgcolor = "#FFECE6"

--- a/permafrost_benchmark_system/data/ilamb.cfg
+++ b/permafrost_benchmark_system/data/ilamb.cfg
@@ -1,4 +1,4 @@
-# Benchmark CMIP5-compatible model outputs against all available benchmarks.
+# Benchmark CMIP5-compatible model outputs against available datasets.
 
 [h1: Permafrost Benchmark System]
 bgcolor = "#FFECE6"

--- a/permafrost_benchmark_system/file.py
+++ b/permafrost_benchmark_system/file.py
@@ -62,7 +62,8 @@ class IlambConfigFile(object):
     def __init__(self,
                  variables,
                  relationships=False,
-                 config_file='ilamb.cfg'):
+                 config_file='ilamb.cfg',
+                 title='Permafrost Benchmark System'):
 
         """Set parameters for an ILAMB config file.
 
@@ -78,6 +79,9 @@ class IlambConfigFile(object):
         config_file : str, optional
             The name of the ILAMB config file (default is
             **ilamb.cfg**).
+        title : str, optional
+            A name for the ILAMB run (default is *Permafrost Benchmark
+            System*).
 
         Examples
         --------
@@ -98,6 +102,7 @@ class IlambConfigFile(object):
         self.has_relationships = relationships
         if len(self.variables) < 2 and self.has_relationships:
             raise TypeError('Two variables are needed for a relationship')
+        self.title = title
 
     def setup(self):
         """Generate settings for an ILAMB config file."""
@@ -163,10 +168,13 @@ class IlambConfigFile(object):
                 self.config[var].write(fp)
 
     def _write_header(self, ofp):
-        header_file = self.get_template_file('header')
-        with open(header_file, 'r') as ifp:
-            header = ifp.read()
-        ofp.write(header + '\n')
+        header = '''
+# Benchmark CMIP5-compatible model outputs against available datasets.
+
+[h1: {}]
+bgcolor = "#FFECE6"{}
+'''.strip().format(self.title, '\n\n')
+        ofp.write(header)
 
     def _make_relationships(self, var_list):
         relations = list()

--- a/permafrost_benchmark_system/tests/test_ilambconfigfile.py
+++ b/permafrost_benchmark_system/tests/test_ilambconfigfile.py
@@ -13,6 +13,7 @@ default_config_file_path = os.path.join(data_directory, default_config_file)
 n_sources = 12
 gpp_template_file = 'gpp.cfg.tmpl'
 relationship = '"LeafAreaIndex/AVHRR"'
+default_title = 'Permafrost Benchmark System'
 
 
 @raises(TypeError)
@@ -61,6 +62,19 @@ def test_config_file_user():
     config_file = 'foo.cfg'
     x = IlambConfigFile(param, config_file=config_file)
     assert_equal(x.config_file, config_file)
+
+
+def test_title_default():
+    param = 'gpp'
+    x = IlambConfigFile(param)
+    assert_equal(x.title, default_title)
+
+
+def test_title_user():
+    param = 'gpp'
+    title = 'ILAMB rulz!'
+    x = IlambConfigFile(param, title=title)
+    assert_equal(x.title, title)
 
 
 def test_relationships_default():


### PR DESCRIPTION
The title had been set as "Permafrost Benchmark System". This is now the default, but a user can override it through the `title` keyword when creating an `IlambConfigFile` instance. The header is now generated in code, instead of reading it from a file.