### PR TITLE
Set up model ingest tool

### DIFF
--- a/permafrost_benchmark_system/bmi_ingest.py
+++ b/permafrost_benchmark_system/bmi_ingest.py
@@ -18,15 +18,19 @@ class BmiIngestToolBase(Bmi):
 
     def initialize(self, filename):
         self._config_file = filename
+        self._tool.load(self._config_file)
 
     def update(self):
-        self._time = self.get_end_time()
+        if self.get_current_time() < self.get_end_time():
+            self._time = self.get_end_time()
+            self._tool.validate()
+            self._tool.move()
 
     def update_until(self, time):
         self.update()
 
     def finalize(self):
-        pass
+        self._tool.cleanup()
 
     def get_input_var_names(self):
         return ()

--- a/permafrost_benchmark_system/bmi_ingest.py
+++ b/permafrost_benchmark_system/bmi_ingest.py
@@ -30,7 +30,7 @@ class BmiIngestToolBase(Bmi):
         self.update()
 
     def finalize(self):
-        pass
+        self._tool = None
 
     def get_input_var_names(self):
         return ()

--- a/permafrost_benchmark_system/bmi_ingest.py
+++ b/permafrost_benchmark_system/bmi_ingest.py
@@ -30,7 +30,7 @@ class BmiIngestToolBase(Bmi):
         self.update()
 
     def finalize(self):
-        self._tool.cleanup()
+        pass
 
     def get_input_var_names(self):
         return ()

--- a/permafrost_benchmark_system/file.py
+++ b/permafrost_benchmark_system/file.py
@@ -183,3 +183,26 @@ bgcolor = "#FFECE6"{}
                             self.sources[var]['benchmark_source']])
             relations.append('"' + src + '"')
         return relations
+
+
+class IngestFile(object):
+    """
+    A file of model outputs or benchmark data to be ingested into PBS.
+
+    Attributes
+    ----------
+    name : str
+      The name of the file.
+    is_valid : bool
+      Set to True if the file is a valid model output or benchmark
+      data file.
+
+    Parameters
+    ----------
+    filename : str or None, optional
+      The name of the file (default is None).
+
+    """
+    def __init__(self, filename=None):
+        self.name = filename
+        self.is_valid = False

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -1,4 +1,5 @@
 """Perform ingest operations in PBS."""
+import os
 import shutil
 import yaml
 from .file import IngestFile
@@ -31,8 +32,30 @@ class ModelIngest(object):
     def move(self):
         for f in self.ingest_files:
             if f.is_valid:
-                shutil.move(f.name, models_dir)
+                try:
+                    shutil.move(f.name, models_dir)
+                except:
+                    _leave_file_exists_note(f.name)
+                    os.remove(f.name)
+                else:
+                    _leave_file_moved_note(f.name)
 
+    def _leave_file_exists_note(self, filename):
+        msg = '''# File Exists\n
+The file `{1}/{0}` already exists in the PBS data store. The file has not been updated.
+'''.format(filename, models_dir)
+        with open(filename + '.txt', 'w') as fp:
+            fp.write(msg)
+
+    def _leave_file_moved_note(self, filename):
+        msg = '''# File Moved\n
+The file `{}` has been moved to `{}` in the PBS data store.
+'''.format(filename, models_dir)
+        with open(filename + '.txt', 'w') as fp:
+            fp.write(msg)
+
+    def cleanup(self):
+        pass
 
 class BenchmarkIngest(object):
 

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -6,6 +6,13 @@ from .file import IngestFile
 
 
 models_dir = '/nas/data/tmp'
+file_exists_msg = '''# File Exists\n
+The file `{1}/{0}` already exists in the PBS data store.
+The file has not been updated.
+'''
+file_moved_msg = '''# File Moved\n
+The file `{}` has been moved to `{}` in the PBS data store.
+'''
 
 
 class ModelIngest(object):
@@ -32,27 +39,20 @@ class ModelIngest(object):
     def move(self):
         for f in self.ingest_files:
             if f.is_valid:
+                msg = ''
                 try:
                     shutil.move(f.name, models_dir)
                 except:
-                    _leave_file_exists_note(f.name)
+                    msg = file_exists_msg.format(f.name, models_dir)
                     os.remove(f.name)
                 else:
-                    _leave_file_moved_note(f.name)
+                    msg = file_moved_msg.format(f.name, models_dir)
+                finally:
+                    self._leave_file_note(f.name, msg)
 
-    def _leave_file_exists_note(self, filename):
-        msg = '''# File Exists\n
-The file `{1}/{0}` already exists in the PBS data store. The file has not been updated.
-'''.format(filename, models_dir)
+    def _leave_file_note(self, filename, mesg):
         with open(filename + '.txt', 'w') as fp:
-            fp.write(msg)
-
-    def _leave_file_moved_note(self, filename):
-        msg = '''# File Moved\n
-The file `{}` has been moved to `{}` in the PBS data store.
-'''.format(filename, models_dir)
-        with open(filename + '.txt', 'w') as fp:
-            fp.write(msg)
+            fp.write(mesg)
 
     def cleanup(self):
         pass

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -39,14 +39,12 @@ class ModelIngest(object):
     def move(self):
         for f in self.ingest_files:
             if f.is_valid:
-                msg = ''
+                msg = file_moved_msg.format(f.name, models_dir)
                 try:
                     shutil.move(f.name, models_dir)
                 except:
                     msg = file_exists_msg.format(f.name, models_dir)
                     os.remove(f.name)
-                else:
-                    msg = file_moved_msg.format(f.name, models_dir)
                 finally:
                     self._leave_file_note(f.name, msg)
 

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -94,9 +94,6 @@ class ModelIngest(object):
         with open(filename + '.txt', 'w') as fp:
             fp.write(mesg)
 
-    def cleanup(self):
-        pass
-
 
 class BenchmarkIngest(object):
 

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -63,9 +63,14 @@ class ModelIngest(object):
         for f in self.ingest_files:
             f.is_valid = True
 
-    def move(self):
+    def move(self, dest=None):
         """
         Move ingest files to the ILAMB MODELS directory.
+
+        Parameters
+        ----------
+        dest : str, optional
+          The destination path (default is None).
 
         Notes
         -----
@@ -75,13 +80,15 @@ class ModelIngest(object):
         the file was not moved.
 
         """
+        if not dest:
+            dest = models_dir
         for f in self.ingest_files:
             if f.is_valid:
-                msg = file_moved_msg.format(f.name, models_dir)
+                msg = file_moved_msg.format(f.name, dest)
                 try:
-                    shutil.move(f.name, models_dir)
+                    shutil.move(f.name, dest)
                 except:
-                    msg = file_exists_msg.format(f.name, models_dir)
+                    msg = file_exists_msg.format(f.name, dest)
                     os.remove(f.name)
                 finally:
                     self._leave_file_note(f.name, msg)

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -66,14 +66,9 @@ class ModelIngest(object):
         for f in self.ingest_files:
             f.is_valid = True
 
-    def move(self, dest=None):
+    def move(self):
         """
         Move ingest files to the ILAMB MODELS directory.
-
-        Parameters
-        ----------
-        dest : str, optional
-          The destination path (default is None).
 
         Notes
         -----
@@ -83,15 +78,13 @@ class ModelIngest(object):
         the file was not moved.
 
         """
-        if not dest:
-            dest = models_dir
         for f in self.ingest_files:
             if f.is_valid:
-                msg = file_moved_msg.format(f.name, dest)
+                msg = file_moved_msg.format(f.name, self.models_dir)
                 try:
-                    shutil.move(f.name, dest)
+                    shutil.move(f.name, self.models_dir)
                 except:
-                    msg = file_exists_msg.format(f.name, dest)
+                    msg = file_exists_msg.format(f.name, self.models_dir)
                     os.remove(f.name)
                 finally:
                     self._leave_file_note(f.name, msg)

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -1,12 +1,27 @@
 """Perform ingest operations in PBS."""
+import yaml
+from .file import IngestFile
+
+
+models_dir = '/nas/data/tmp'
 
 
 class ModelIngest(object):
 
     """Operator for uploading model outputs into PBS."""
 
-    def __init__(self):
-        pass
+    def __init__(self, ingest_file=None):
+        self.ingest_files = []
+        self.make_public = True
+        if ingest_file is not None:
+            self.load(ingest_file)
+
+    def load(self, ingest_file):
+        with open(ingest_file, 'r') as fp:
+            cfg = yaml.safe_load(fp)
+        for f in cfg['ingest_files']:
+            self.ingest_files.append(IngestFile(f))
+        self.make_public = cfg['make_public']
 
 
 class BenchmarkIngest(object):

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -85,7 +85,8 @@ class ModelIngest(object):
                     shutil.move(f.name, self.models_dir)
                 except:
                     msg = file_exists_msg.format(f.name, self.models_dir)
-                    os.remove(f.name)
+                    if os.path.exists(f.name):
+                        os.remove(f.name)
                 finally:
                     self._leave_file_note(f.name, msg)
 

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -1,4 +1,5 @@
 """Perform ingest operations in PBS."""
+import shutil
 import yaml
 from .file import IngestFile
 
@@ -22,6 +23,15 @@ class ModelIngest(object):
         for f in cfg['ingest_files']:
             self.ingest_files.append(IngestFile(f))
         self.make_public = cfg['make_public']
+
+    def validate(self):
+        for f in self.ingest_files:
+            f.is_valid = True
+
+    def move(self):
+        for f in self.ingest_files:
+            if f.is_valid:
+                shutil.move(f.name, models_dir)
 
 
 class BenchmarkIngest(object):

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -1,4 +1,5 @@
 """Perform ingest operations in PBS."""
+
 import os
 import shutil
 import yaml
@@ -6,6 +7,7 @@ from .file import IngestFile
 
 
 models_dir = '/nas/data/tmp'
+
 file_exists_msg = '''# File Exists\n
 The file `{1}/{0}` already exists in the PBS data store.
 The file has not been updated.
@@ -16,9 +18,22 @@ The file `{}` has been moved to `{}` in the PBS data store.
 
 
 class ModelIngest(object):
+    """
+    Operator for uploading model outputs into PBS.
 
-    """Operator for uploading model outputs into PBS."""
+    Parameters
+    ----------
+    ingest_file : str, optional
+      Path to the configuration file (default is None).
 
+    Attributes
+    ----------
+    ingest_files : list
+      List of files to ingest.
+    make_public : bool
+      Set to True to allow others to see and use ingested files.
+
+    """
     def __init__(self, ingest_file=None):
         self.ingest_files = []
         self.make_public = True
@@ -26,6 +41,15 @@ class ModelIngest(object):
             self.load(ingest_file)
 
     def load(self, ingest_file):
+        """
+        Read and parse the contents of a configuration file.
+
+        Parameters
+        ----------
+        ingest_file : str
+          Path to the configuration file.
+
+        """
         with open(ingest_file, 'r') as fp:
             cfg = yaml.safe_load(fp)
         for f in cfg['ingest_files']:
@@ -33,10 +57,24 @@ class ModelIngest(object):
         self.make_public = cfg['make_public']
 
     def validate(self):
+        """
+        Validate ingest files against the CMIP5 standard format.
+        """
         for f in self.ingest_files:
             f.is_valid = True
 
     def move(self):
+        """
+        Move ingest files to the ILAMB MODELS directory.
+
+        Notes
+        -----
+        A file that is moved is replaced with a text file listing the
+        new location of the file. If the file exists in the target
+        location, the file is replaced with a text file stating that
+        the file was not moved.
+
+        """
         for f in self.ingest_files:
             if f.is_valid:
                 msg = file_moved_msg.format(f.name, models_dir)
@@ -54,6 +92,7 @@ class ModelIngest(object):
 
     def cleanup(self):
         pass
+
 
 class BenchmarkIngest(object):
 

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -6,8 +6,6 @@ import yaml
 from .file import IngestFile
 
 
-models_dir = '/nas/data/tmp'
-
 file_exists_msg = '''# File Exists\n
 The file `{1}/{0}` already exists in the PBS data store.
 The file has not been updated.
@@ -25,16 +23,21 @@ class ModelIngest(object):
     ----------
     ingest_file : str, optional
       Path to the configuration file (default is None).
+    models_dir : str, optional
+      Path to the ILAMB MODELS directory (default is /nas/data/ilamb/MODELS).
 
     Attributes
     ----------
+    models_dir : str
+      Path to the ILAMB MODELS directory.
     ingest_files : list
       List of files to ingest.
     make_public : bool
       Set to True to allow others to see and use ingested files.
 
     """
-    def __init__(self, ingest_file=None):
+    def __init__(self, ingest_file=None, models_dir='/nas/data/ilamb/MODELS'):
+        self.models_dir = models_dir
         self.ingest_files = []
         self.make_public = True
         if ingest_file is not None:

--- a/permafrost_benchmark_system/tests/__init__.py
+++ b/permafrost_benchmark_system/tests/__init__.py
@@ -1,0 +1,20 @@
+"""Unit tests for the permafrost_benchmark_system package."""
+
+import yaml
+
+
+ingest_file = 'test_ingest.yaml'
+model_file = 'test_model.txt'
+note_file = model_file + '.txt'
+tmp_dir = 'tmp'
+
+
+def make_test_files():
+    """
+    Creates sample files for testing.
+    """
+    with open(model_file, 'w') as fp:
+        fp.write('This is a test model output file.\n')
+    cfg = {'ingest_files': [model_file], 'make_public': True}
+    with open(ingest_file, 'w') as fp:
+        yaml.safe_dump(cfg, fp, default_flow_style=False)

--- a/permafrost_benchmark_system/tests/test_bmimodelingesttool.py
+++ b/permafrost_benchmark_system/tests/test_bmimodelingesttool.py
@@ -1,0 +1,95 @@
+"""Tests for the BmiModelIngestTool class."""
+
+import os
+import shutil
+import yaml
+from nose.tools import nottest, assert_true, assert_equal, assert_is_none
+from permafrost_benchmark_system.bmi_ingest import BmiModelIngestTool
+from . import (ingest_file, model_file, note_file, tmp_dir,
+               make_test_files)
+
+
+def setup_module():
+    make_test_files()
+    os.mkdir(tmp_dir)
+
+
+def teardown_module():
+    shutil.rmtree(tmp_dir)
+    for f in [ingest_file, model_file, note_file]:
+        try:
+            os.remove(f)
+        except:
+            pass
+
+
+def test_init():
+    x = BmiModelIngestTool()
+    assert_true(isinstance(x, BmiModelIngestTool))
+
+
+def test_get_component_name():
+    x = BmiModelIngestTool()
+    assert_equal(x.get_component_name(), BmiModelIngestTool._component_name)
+
+
+def test_initialize():
+    x = BmiModelIngestTool()
+    x.initialize(ingest_file)
+    assert_equal(x._tool.ingest_files[0].name, model_file)
+
+
+def test_update():
+    x = BmiModelIngestTool()
+    x.initialize(ingest_file)
+    x.update()
+    assert_true(os.path.isfile(note_file))
+
+
+def test_update_until():
+    x = BmiModelIngestTool()
+    x.initialize(ingest_file)
+    end_time = 5.0
+    x.update_until(end_time)
+    assert_true(os.path.isfile(note_file))
+
+
+def test_finalize():
+    x = BmiModelIngestTool()
+    x.finalize()
+    assert_is_none(x._tool)
+
+
+def test_get_input_var_names():
+    x = BmiModelIngestTool()
+    assert_equal(x.get_input_var_names(), ())
+
+
+def test_get_output_var_names():
+    x = BmiModelIngestTool()
+    assert_equal(x.get_output_var_names(), ())
+
+
+def test_get_start_time():
+    x = BmiModelIngestTool()
+    assert_equal(x.get_start_time(), 0.0)
+
+
+def test_get_end_time():
+    x = BmiModelIngestTool()
+    assert_equal(x.get_end_time(), 1.0)
+
+
+def test_get_current_time():
+    x = BmiModelIngestTool()
+    assert_equal(x.get_current_time(), x.get_start_time())
+
+
+def test_get_time_step():
+    x = BmiModelIngestTool()
+    assert_equal(x.get_time_step(), 1.0)
+
+
+def test_get_time_units():
+    x = BmiModelIngestTool()
+    assert_equal(x.get_time_units(), 's')

--- a/permafrost_benchmark_system/tests/test_file.py
+++ b/permafrost_benchmark_system/tests/test_file.py
@@ -3,7 +3,8 @@
 import os
 from nose.tools import raises, assert_true, assert_equal
 from permafrost_benchmark_system.file import (get_region_labels_txt,
-                                              get_region_labels_ncdf)
+                                              get_region_labels_ncdf,
+                                              IngestFile)
 from permafrost_benchmark_system import data_directory
 
 
@@ -43,3 +44,19 @@ def test_get_region_labels_ncdf_type():
 def test_get_region_labels_ncdf_value():
     x = get_region_labels_ncdf(regions_file_nc_path)
     assert_equal(x[0:3], labels_nc)
+
+
+def test_ingestfile_no_params():
+    x = IngestFile()
+    assert_true(isinstance(x, IngestFile))
+
+
+def test_ingestfile_one_param():
+    x = IngestFile(regions_file_nc)
+    assert_true(x.name, regions_file_nc)
+
+
+def test_ingestfile_set_name():
+    x = IngestFile()
+    x.name = regions_file_nc
+    assert_true(x.name, regions_file_nc)

--- a/permafrost_benchmark_system/tests/test_modelingest.py
+++ b/permafrost_benchmark_system/tests/test_modelingest.py
@@ -1,0 +1,86 @@
+"""Tests for the ModelIngest class."""
+
+import os
+import shutil
+import yaml
+from nose.tools import nottest, assert_true, assert_equal
+from permafrost_benchmark_system.ingest import ModelIngest
+
+
+ingest_file = 'test_ingest.yaml'
+model_file = 'test_model.txt'
+note_file = model_file + '.txt'
+tmp_dir = 'tmp'
+
+
+@nottest
+def make_test_files():
+    with open(model_file, 'w') as fp:
+        fp.write('This is a test model output file.\n')
+    cfg = {'ingest_files': [model_file], 'make_public': True}
+    with open(ingest_file, 'w') as fp:
+        yaml.safe_dump(cfg, fp, default_flow_style=False)
+
+
+def setup_module():
+    make_test_files()
+    os.mkdir(tmp_dir)
+
+
+def teardown_module():
+    shutil.rmtree(tmp_dir)
+    for f in [ingest_file, model_file, note_file]:
+        try:
+            os.remove(f)
+        except:
+            pass
+
+
+def test_init_no_parameters():
+    x = ModelIngest()
+    assert_true(isinstance(x, ModelIngest))
+
+
+def test_load():
+    x = ModelIngest()
+    x.load(ingest_file)
+    assert_equal(x.ingest_files[0].name, model_file)
+
+
+def test_init_one_parameter():
+    x = ModelIngest(ingest_file=ingest_file)
+    assert_equal(x.ingest_files[0].name, model_file)
+
+
+def test_validate():
+    pass
+
+
+def test_leave_file_note():
+    x = ModelIngest()
+    msg = 'Hi there'
+    x._leave_file_note(model_file, msg)
+    assert_true(os.path.isfile(note_file))
+
+
+def test_move_file_new():
+    x = ModelIngest()
+    x.load(ingest_file)
+    x.validate()
+    x.move(tmp_dir)
+    assert_true(os.path.isfile(os.path.join('tmp', model_file)))
+    assert_true(os.path.isfile(note_file))
+
+
+def test_move_file_exists():
+    make_test_files()
+    x = ModelIngest()
+    x.load(ingest_file)
+    x.validate()
+    x.move(tmp_dir)
+    assert_true(os.path.isfile(os.path.join('tmp', model_file)))
+    assert_true(os.path.isfile(note_file))
+
+
+def test_cleanup():
+    pass

--- a/permafrost_benchmark_system/tests/test_modelingest.py
+++ b/permafrost_benchmark_system/tests/test_modelingest.py
@@ -36,9 +36,15 @@ def teardown_module():
             pass
 
 
-def test_init_no_parameters():
+def test_init():
     x = ModelIngest()
     assert_true(isinstance(x, ModelIngest))
+
+
+def test_init_with_models_dir():
+    x = ModelIngest(models_dir=tmp_dir)
+    assert_true(isinstance(x, ModelIngest))
+    assert_equal(x.models_dir, tmp_dir)
 
 
 def test_load():
@@ -47,9 +53,16 @@ def test_load():
     assert_equal(x.ingest_files[0].name, model_file)
 
 
-def test_init_one_parameter():
+def test_init_with_ingest_file():
     x = ModelIngest(ingest_file=ingest_file)
+    assert_true(isinstance(x, ModelIngest))
     assert_equal(x.ingest_files[0].name, model_file)
+
+
+def test_set_models_dir():
+    x = ModelIngest()
+    x.models_dir = tmp_dir
+    assert_equal(x.models_dir, tmp_dir)
 
 
 def test_validate():

--- a/permafrost_benchmark_system/tests/test_modelingest.py
+++ b/permafrost_benchmark_system/tests/test_modelingest.py
@@ -77,20 +77,20 @@ def test_leave_file_note():
 
 
 def test_move_file_new():
-    x = ModelIngest()
+    x = ModelIngest(models_dir=tmp_dir)
     x.load(ingest_file)
     x.validate()
-    x.move(tmp_dir)
-    assert_true(os.path.isfile(os.path.join('tmp', model_file)))
+    x.move()
+    assert_true(os.path.isfile(os.path.join(tmp_dir, model_file)))
     assert_true(os.path.isfile(note_file))
 
 
 def test_move_file_exists():
     make_test_files()
-    x = ModelIngest()
+    x = ModelIngest(models_dir=tmp_dir)
     x.load(ingest_file)
     x.validate()
-    x.move(tmp_dir)
+    x.move()
     assert_true(os.path.isfile(os.path.join('tmp', model_file)))
     assert_true(os.path.isfile(note_file))
 

--- a/permafrost_benchmark_system/tests/test_modelingest.py
+++ b/permafrost_benchmark_system/tests/test_modelingest.py
@@ -79,7 +79,3 @@ def test_move_file_exists():
     x.move()
     assert_true(os.path.isfile(os.path.join('tmp', model_file)))
     assert_true(os.path.isfile(note_file))
-
-
-def test_cleanup():
-    pass

--- a/permafrost_benchmark_system/tests/test_modelingest.py
+++ b/permafrost_benchmark_system/tests/test_modelingest.py
@@ -2,24 +2,10 @@
 
 import os
 import shutil
-import yaml
 from nose.tools import nottest, assert_true, assert_equal
 from permafrost_benchmark_system.ingest import ModelIngest
-
-
-ingest_file = 'test_ingest.yaml'
-model_file = 'test_model.txt'
-note_file = model_file + '.txt'
-tmp_dir = 'tmp'
-
-
-@nottest
-def make_test_files():
-    with open(model_file, 'w') as fp:
-        fp.write('This is a test model output file.\n')
-    cfg = {'ingest_files': [model_file], 'make_public': True}
-    with open(ingest_file, 'w') as fp:
-        yaml.safe_dump(cfg, fp, default_flow_style=False)
+from . import (ingest_file, model_file, note_file, tmp_dir,
+               make_test_files)
 
 
 def setup_module():


### PR DESCRIPTION
This PR contains the initial setup for the Model Ingest Tool (MIT). It transfers files uploaded through the MIT component in WMT to a temporary location, **/nas/data/tmp**, on ***beach***. A message is left in the execution directory for each file that is moved.

Once the Validation Tool (VT) is written, the MIT will be updated to place ingested files the appropriate location in the ILAMB MODELS directory.