### PR TITLE
Revise model ingest tool

### DIFF
--- a/.bmi/benchmark_ingest_tool/ingest.yaml.tmpl
+++ b/.bmi/benchmark_ingest_tool/ingest.yaml.tmpl
@@ -1,2 +1,4 @@
+ilamb_root: {ilamb_root}
+dest_dir: {dest_dir}
 ingest_files: {ingest_files}
 make_public: {make_public}

--- a/.bmi/benchmark_ingest_tool/parameters.yaml
+++ b/.bmi/benchmark_ingest_tool/parameters.yaml
@@ -1,9 +1,24 @@
+ilamb_root:
+  description:
+    'Path to the ILAMB benchmark data and model output repository (ILAMB_ROOT)'
+  value:
+    type: string
+    default: /nas/data/ilamb
+
+dest_dir:
+  description:
+    Directory relative to ILAMB_ROOT where benchmark datasets are stored
+  value:
+    type: string
+    default: DATA
+
 ingest_files:
   description:
     A list of benchmark data files to ingest
   value:
     type: list
     default: []
+
 make_public:
   description: Allow others to use these benchmark datasets?
   value:

--- a/.bmi/model_ingest_tool/ingest.yaml.tmpl
+++ b/.bmi/model_ingest_tool/ingest.yaml.tmpl
@@ -1,2 +1,4 @@
+ilamb_root: {ilamb_root}
+dest_dir: {dest_dir}
 ingest_files: {ingest_files}
 make_public: {make_public}

--- a/.bmi/model_ingest_tool/parameters.yaml
+++ b/.bmi/model_ingest_tool/parameters.yaml
@@ -1,9 +1,24 @@
+ilamb_root:
+  description:
+    'Path to the ILAMB benchmark data and model output repository (ILAMB_ROOT)'
+  value:
+    type: string
+    default: /nas/data/ilamb
+
+dest_dir:
+  description:
+    Directory relative to ILAMB_ROOT where model outputs are stored
+  value:
+    type: string
+    default: MODELS
+
 ingest_files:
   description:
     A list of model output files to ingest
   value:
     type: list
     default: []
+
 make_public:
   description: Allow others to use these model outputs?
   value:

--- a/permafrost_benchmark_system/bmi_ingest.py
+++ b/permafrost_benchmark_system/bmi_ingest.py
@@ -23,7 +23,7 @@ class BmiIngestToolBase(Bmi):
     def update(self):
         if self.get_current_time() < self.get_end_time():
             self._time = self.get_end_time()
-            self._tool.validate()
+            self._tool.verify()
             self._tool.move()
 
     def update_until(self, time):

--- a/permafrost_benchmark_system/bmi_ingest.py
+++ b/permafrost_benchmark_system/bmi_ingest.py
@@ -1,7 +1,7 @@
 """Define the BMI for the PBS ingest tools."""
 
 from basic_modeling_interface import Bmi
-from .ingest import ModelIngest, BenchmarkIngest
+from .ingest import ModelIngestTool, BenchmarkIngestTool
 
 
 class BmiIngestToolBase(Bmi):
@@ -60,7 +60,7 @@ class BmiModelIngestTool(BmiIngestToolBase):
 
     def __init__(self):
         super(BmiModelIngestTool, self).__init__()
-        self._tool = ModelIngest()
+        self._tool = ModelIngestTool()
 
 
 class BmiBenchmarkIngestTool(BmiIngestToolBase):
@@ -69,4 +69,4 @@ class BmiBenchmarkIngestTool(BmiIngestToolBase):
 
     def __init__(self):
         super(BmiBenchmarkIngestTool, self).__init__()
-        self._tool = BenchmarkIngest()
+        self._tool = BenchmarkIngestTool()

--- a/permafrost_benchmark_system/file.py
+++ b/permafrost_benchmark_system/file.py
@@ -189,20 +189,20 @@ class IngestFile(object):
     """
     A file of model outputs or benchmark data to be ingested into PBS.
 
-    Attributes
-    ----------
-    name : str
-      The name of the file.
-    is_valid : bool
-      Set to True if the file is a valid model output or benchmark
-      data file.
-
     Parameters
     ----------
     filename : str or None, optional
       The name of the file (default is None).
 
+    Attributes
+    ----------
+    name : str
+      The name of the file.
+    is_verified : bool
+      Set to True if the file is a verified model output or benchmark
+      data file.
+
     """
     def __init__(self, filename=None):
         self.name = filename
-        self.is_valid = False
+        self.is_verified = False

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -23,11 +23,13 @@ class ModelIngestTool(object):
     ----------
     ingest_file : str, optional
       Path to the configuration file (default is None).
-    models_dir : str, optional
-      Path to the ILAMB MODELS directory (default is /nas/data/ilamb/MODELS).
 
     Attributes
     ----------
+    ilamb_root : str
+      Path to the ILAMB root directory.
+    dest_dir : str
+      Directory relative to ILAMB_ROOT where model outputs are stored.
     models_dir : str
       Path to the ILAMB MODELS directory.
     ingest_files : list
@@ -36,8 +38,10 @@ class ModelIngestTool(object):
       Set to True to allow others to see and use ingested files.
 
     """
-    def __init__(self, ingest_file=None, models_dir='/nas/data/ilamb/MODELS'):
-        self.models_dir = models_dir
+    def __init__(self, ingest_file=None):
+        self.ilamb_root = None
+        self.dest_dir = None
+        self.models_dir = None
         self.ingest_files = []
         self.make_public = True
         if ingest_file is not None:
@@ -55,6 +59,9 @@ class ModelIngestTool(object):
         """
         with open(ingest_file, 'r') as fp:
             cfg = yaml.safe_load(fp)
+        self.ilamb_root = cfg['ilamb_root']
+        self.dest_dir = cfg['dest_dir']
+        self.models_dir = os.path.join(self.ilamb_root, self.dest_dir)
         for f in cfg['ingest_files']:
             self.ingest_files.append(IngestFile(f))
         self.make_public = cfg['make_public']

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -15,9 +15,9 @@ The file `{}` has been moved to `{}` in the PBS data store.
 '''
 
 
-class ModelIngest(object):
+class ModelIngestTool(object):
     """
-    Operator for uploading model outputs into PBS.
+    Tool for uploading CMIP5-compatible model outputs into PBS.
 
     Parameters
     ----------
@@ -95,9 +95,9 @@ class ModelIngest(object):
             fp.write(mesg)
 
 
-class BenchmarkIngest(object):
+class BenchmarkIngestTool(object):
 
-    """Operator for uploading benchmark datasets into PBS."""
+    """Tool for uploading benchmark datasets into PBS."""
 
     def __init__(self):
         pass

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -59,12 +59,12 @@ class ModelIngest(object):
             self.ingest_files.append(IngestFile(f))
         self.make_public = cfg['make_public']
 
-    def validate(self):
+    def verify(self):
         """
-        Validate ingest files against the CMIP5 standard format.
+        Check whether ingest files use the CMIP5 standard format.
         """
         for f in self.ingest_files:
-            f.is_valid = True
+            f.is_verified = True
 
     def move(self):
         """
@@ -79,7 +79,7 @@ class ModelIngest(object):
 
         """
         for f in self.ingest_files:
-            if f.is_valid:
+            if f.is_verified:
                 msg = file_moved_msg.format(f.name, self.models_dir)
                 try:
                     shutil.move(f.name, self.models_dir)

--- a/permafrost_benchmark_system/tests/__init__.py
+++ b/permafrost_benchmark_system/tests/__init__.py
@@ -1,5 +1,6 @@
 """Unit tests for the permafrost_benchmark_system package."""
 
+import os
 import yaml
 
 
@@ -15,6 +16,11 @@ def make_test_files():
     """
     with open(model_file, 'w') as fp:
         fp.write('This is a test model output file.\n')
-    cfg = {'ingest_files': [model_file], 'make_public': True}
+
+    cfg = dict()
+    cfg['ilamb_root'] = os.getcwd()
+    cfg['dest_dir'] = tmp_dir
+    cfg['ingest_files'] = [model_file]
+    cfg['make_public'] = True
     with open(ingest_file, 'w') as fp:
         yaml.safe_dump(cfg, fp, default_flow_style=False)

--- a/permafrost_benchmark_system/tests/test_bmimodelingesttool.py
+++ b/permafrost_benchmark_system/tests/test_bmimodelingesttool.py
@@ -2,8 +2,7 @@
 
 import os
 import shutil
-import yaml
-from nose.tools import nottest, assert_true, assert_equal, assert_is_none
+from nose.tools import raises, assert_true, assert_equal, assert_is_none
 from permafrost_benchmark_system.bmi_ingest import BmiModelIngestTool
 from . import (ingest_file, model_file, note_file, tmp_dir,
                make_test_files)
@@ -37,6 +36,12 @@ def test_initialize():
     x = BmiModelIngestTool()
     x.initialize(ingest_file)
     assert_equal(x._tool.ingest_files[0].name, model_file)
+
+
+@raises(TypeError)
+def test_initialize_no_args():
+    x = BmiModelIngestTool()
+    x.initialize()
 
 
 def test_update():

--- a/permafrost_benchmark_system/tests/test_ilambconfigfile.py
+++ b/permafrost_benchmark_system/tests/test_ilambconfigfile.py
@@ -16,6 +16,17 @@ relationship = '"LeafAreaIndex/AVHRR"'
 default_title = 'Permafrost Benchmark System'
 
 
+def setup_module():
+    pass
+
+
+def teardown_module():
+    try:
+        os.remove(default_config_file)
+    except:
+        pass
+
+
 @raises(TypeError)
 def test_init_no_parameters():
     IlambConfigFile()

--- a/permafrost_benchmark_system/tests/test_modelingest.py
+++ b/permafrost_benchmark_system/tests/test_modelingest.py
@@ -51,7 +51,7 @@ def test_set_models_dir():
     assert_equal(x.models_dir, tmp_dir)
 
 
-def test_validate():
+def test_verify():
     pass
 
 
@@ -65,7 +65,7 @@ def test_leave_file_note():
 def test_move_file_new():
     x = ModelIngest(models_dir=tmp_dir)
     x.load(ingest_file)
-    x.validate()
+    x.verify()
     x.move()
     assert_true(os.path.isfile(os.path.join(tmp_dir, model_file)))
     assert_true(os.path.isfile(note_file))
@@ -75,7 +75,7 @@ def test_move_file_exists():
     make_test_files()
     x = ModelIngest(models_dir=tmp_dir)
     x.load(ingest_file)
-    x.validate()
+    x.verify()
     x.move()
     assert_true(os.path.isfile(os.path.join('tmp', model_file)))
     assert_true(os.path.isfile(note_file))

--- a/permafrost_benchmark_system/tests/test_modelingest.py
+++ b/permafrost_benchmark_system/tests/test_modelingest.py
@@ -1,9 +1,9 @@
-"""Tests for the ModelIngest class."""
+"""Tests for the ModelIngestTool class."""
 
 import os
 import shutil
 from nose.tools import nottest, assert_true, assert_equal
-from permafrost_benchmark_system.ingest import ModelIngest
+from permafrost_benchmark_system.ingest import ModelIngestTool
 from . import (ingest_file, model_file, note_file, tmp_dir,
                make_test_files)
 
@@ -23,30 +23,30 @@ def teardown_module():
 
 
 def test_init():
-    x = ModelIngest()
-    assert_true(isinstance(x, ModelIngest))
+    x = ModelIngestTool()
+    assert_true(isinstance(x, ModelIngestTool))
 
 
 def test_init_with_models_dir():
-    x = ModelIngest(models_dir=tmp_dir)
-    assert_true(isinstance(x, ModelIngest))
+    x = ModelIngestTool(models_dir=tmp_dir)
+    assert_true(isinstance(x, ModelIngestTool))
     assert_equal(x.models_dir, tmp_dir)
 
 
 def test_load():
-    x = ModelIngest()
+    x = ModelIngestTool()
     x.load(ingest_file)
     assert_equal(x.ingest_files[0].name, model_file)
 
 
 def test_init_with_ingest_file():
-    x = ModelIngest(ingest_file=ingest_file)
-    assert_true(isinstance(x, ModelIngest))
+    x = ModelIngestTool(ingest_file=ingest_file)
+    assert_true(isinstance(x, ModelIngestTool))
     assert_equal(x.ingest_files[0].name, model_file)
 
 
 def test_set_models_dir():
-    x = ModelIngest()
+    x = ModelIngestTool()
     x.models_dir = tmp_dir
     assert_equal(x.models_dir, tmp_dir)
 
@@ -56,14 +56,14 @@ def test_verify():
 
 
 def test_leave_file_note():
-    x = ModelIngest()
+    x = ModelIngestTool()
     msg = 'Hi there'
     x._leave_file_note(model_file, msg)
     assert_true(os.path.isfile(note_file))
 
 
 def test_move_file_new():
-    x = ModelIngest(models_dir=tmp_dir)
+    x = ModelIngestTool(models_dir=tmp_dir)
     x.load(ingest_file)
     x.verify()
     x.move()
@@ -73,7 +73,7 @@ def test_move_file_new():
 
 def test_move_file_exists():
     make_test_files()
-    x = ModelIngest(models_dir=tmp_dir)
+    x = ModelIngestTool(models_dir=tmp_dir)
     x.load(ingest_file)
     x.verify()
     x.move()

--- a/permafrost_benchmark_system/tests/test_modelingest.py
+++ b/permafrost_benchmark_system/tests/test_modelingest.py
@@ -2,7 +2,7 @@
 
 import os
 import shutil
-from nose.tools import nottest, assert_true, assert_equal
+from nose.tools import assert_true, assert_equal
 from permafrost_benchmark_system.ingest import ModelIngestTool
 from . import (ingest_file, model_file, note_file, tmp_dir,
                make_test_files)
@@ -27,12 +27,6 @@ def test_init():
     assert_true(isinstance(x, ModelIngestTool))
 
 
-def test_init_with_models_dir():
-    x = ModelIngestTool(models_dir=tmp_dir)
-    assert_true(isinstance(x, ModelIngestTool))
-    assert_equal(x.models_dir, tmp_dir)
-
-
 def test_load():
     x = ModelIngestTool()
     x.load(ingest_file)
@@ -45,10 +39,10 @@ def test_init_with_ingest_file():
     assert_equal(x.ingest_files[0].name, model_file)
 
 
-def test_set_models_dir():
+def test_set_dest_dir():
     x = ModelIngestTool()
-    x.models_dir = tmp_dir
-    assert_equal(x.models_dir, tmp_dir)
+    x.dest_dir = tmp_dir
+    assert_equal(x.dest_dir, tmp_dir)
 
 
 def test_verify():
@@ -63,7 +57,7 @@ def test_leave_file_note():
 
 
 def test_move_file_new():
-    x = ModelIngestTool(models_dir=tmp_dir)
+    x = ModelIngestTool()
     x.load(ingest_file)
     x.verify()
     x.move()
@@ -73,7 +67,7 @@ def test_move_file_new():
 
 def test_move_file_exists():
     make_test_files()
-    x = ModelIngestTool(models_dir=tmp_dir)
+    x = ModelIngestTool()
     x.load(ingest_file)
     x.verify()
     x.move()


### PR DESCRIPTION
Two new parameters, `ilamb_root` and `dest_dir` have been added as parameters to the **ingest.yaml** file. The idea is to make the location where ingested files are eventually placed a configurable parameter instead of hiding this information in the code.

This change has only been implemented in the Model Ingest Tool, but the changes were designed to work with the Benchmark Ingest Tool, as well.