### PR TITLE
Create a logger for the ingest tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda install python=$TRAVIS_PYTHON_VERSION
-  - conda install numpy nose pyyaml netcdf4
+  - conda install numpy nose pyyaml netcdf4 markdown
   - pip install coveralls basic-modeling-interface
 
 install:

--- a/permafrost_benchmark_system/file.py
+++ b/permafrost_benchmark_system/file.py
@@ -244,6 +244,7 @@ class Logger(object):
     """
     def __init__(self, title='Summary'):
         self.data = markdown.markdown('# {}'.format(title))
+        self.write()
 
     def add(self, message):
         """
@@ -256,6 +257,7 @@ class Logger(object):
 
         """
         self.data += markdown.markdown(message)
+        self.write()
 
     def write(self):
         """

--- a/permafrost_benchmark_system/file.py
+++ b/permafrost_benchmark_system/file.py
@@ -2,9 +2,24 @@
 
 import os
 import yaml
+import markdown
 from netCDF4 import Dataset
 from ConfigParser import SafeConfigParser
 from . import data_directory
+
+
+header = '''<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>PBS Ingest Tool Summary</title>
+</head>
+<body>
+'''
+footer = '''
+</body>
+</html>
+'''
 
 
 def get_region_labels_txt(regions_file):
@@ -210,3 +225,44 @@ class IngestFile(object):
         self.name = filename
         self.is_verified = False
         self.data = None
+
+
+class Logger(object):
+    """
+    A tool to generate an HTML log file from Markdown messages.
+
+    Parameters
+    ----------
+    title : str, optional
+      The title of the log file.
+
+    Attributes
+    ----------
+    data : str
+      The contents of the log.
+
+    """
+    def __init__(self, title='Summary'):
+        self.data = markdown.markdown('# {}'.format(title))
+
+    def add(self, message):
+        """
+        Add a message to the log.
+
+        Parameters
+        ----------
+        message : str
+          A message.
+
+        """
+        self.data += markdown.markdown(message)
+
+    def write(self):
+        """
+        Write the log file `index.html`.
+
+        """
+        with open('index.html', 'w') as fp:
+            fp.write(header)
+            fp.write(self.data)
+            fp.write(footer)

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -3,18 +3,18 @@
 import os
 import shutil
 import yaml
-from .file import IngestFile
+from .file import IngestFile, Logger
 from .verify import VerificationTool, VerificationError
 
 
-file_exists = '''# File Exists\n
+file_exists = '''## File Exists\n
 The file `{1}/{0}` already exists in the PBS data store.
 The file has not been updated.
 '''
-file_moved = '''# File Moved\n
+file_moved = '''## File Moved\n
 The file `{}` has been moved to `{}` in the PBS data store.
 '''
-file_not_verified = '''# File Verification Error\n
+file_not_verified = '''## File Verification Error\n
 The file `{}` cannot be ingested into the PBS data store.
 Error message:\n
 {}
@@ -47,6 +47,7 @@ class ModelIngestTool(object):
         self.dest_dir = None
         self.ingest_files = []
         self.make_public = True
+        self.log = Logger(title='Model Ingest Tool Summary')
         if ingest_file is not None:
             self.load(ingest_file)
 
@@ -78,7 +79,7 @@ class ModelIngestTool(object):
                 v.verify()
             except VerificationError as e:
                 msg = file_not_verified.format(f.name, e.msg)
-                self._leave_file_note(f.name, msg)
+                self.log.add(msg)
                 if os.path.exists(f.name):
                     os.remove(f.name)
             else:
@@ -108,11 +109,7 @@ class ModelIngestTool(object):
                     if os.path.exists(f.name):
                         os.remove(f.name)
                 finally:
-                    self._leave_file_note(f.name, msg)
-
-    def _leave_file_note(self, filename, mesg):
-        with open(filename + '.txt', 'w') as fp:
-            fp.write(mesg)
+                    self.log.add(msg)
 
 
 class BenchmarkIngestTool(object):

--- a/permafrost_benchmark_system/tests/__init__.py
+++ b/permafrost_benchmark_system/tests/__init__.py
@@ -6,7 +6,7 @@ import yaml
 
 ingest_file = 'test_ingest.yaml'
 model_file = 'test_model.txt'
-note_file = model_file + '.txt'
+log_file = 'index.html'
 tmp_dir = 'tmp'
 
 

--- a/permafrost_benchmark_system/tests/test_bmimodelingesttool.py
+++ b/permafrost_benchmark_system/tests/test_bmimodelingesttool.py
@@ -4,7 +4,7 @@ import os
 import shutil
 from nose.tools import raises, assert_true, assert_equal, assert_is_none
 from permafrost_benchmark_system.bmi_ingest import BmiModelIngestTool
-from . import (ingest_file, model_file, note_file, tmp_dir,
+from . import (ingest_file, model_file, log_file, tmp_dir,
                make_test_files)
 
 
@@ -15,7 +15,7 @@ def setup_module():
 
 def teardown_module():
     shutil.rmtree(tmp_dir)
-    for f in [ingest_file, model_file, note_file]:
+    for f in [ingest_file, model_file, log_file]:
         try:
             os.remove(f)
         except:
@@ -48,7 +48,7 @@ def test_update():
     x = BmiModelIngestTool()
     x.initialize(ingest_file)
     x.update()
-    assert_true(os.path.isfile(note_file))
+    assert_true(os.path.isfile(log_file))
 
 
 def test_update_until():
@@ -56,7 +56,7 @@ def test_update_until():
     x.initialize(ingest_file)
     end_time = 5.0
     x.update_until(end_time)
-    assert_true(os.path.isfile(note_file))
+    assert_true(os.path.isfile(log_file))
 
 
 def test_finalize():

--- a/permafrost_benchmark_system/tests/test_file.py
+++ b/permafrost_benchmark_system/tests/test_file.py
@@ -4,8 +4,9 @@ import os
 from nose.tools import raises, assert_true, assert_equal
 from permafrost_benchmark_system.file import (get_region_labels_txt,
                                               get_region_labels_ncdf,
-                                              IngestFile)
+                                              IngestFile, Logger)
 from permafrost_benchmark_system import data_directory
+from . import log_file
 
 
 regions_file_txt = 'tropics.txt'
@@ -14,6 +15,18 @@ labels_txt = ['tropics', 'afritrop']
 regions_file_nc = 'basins_0.5x0.5.nc'
 regions_file_nc_path = os.path.join(data_directory, regions_file_nc)
 labels_nc = ['amazon', 'ob', 'lena']
+
+
+def setup_module():
+    pass
+
+
+def teardown_module():
+    for f in [log_file]:
+        try:
+            os.remove(f)
+        except:
+            pass
 
 
 @raises(IOError)
@@ -60,3 +73,23 @@ def test_ingestfile_set_name():
     x = IngestFile()
     x.name = regions_file_nc
     assert_true(x.name, regions_file_nc)
+
+
+def test_logger_init():
+    x = Logger()
+    assert_true(isinstance(x, Logger))
+    assert_true(os.path.isfile(log_file))
+
+
+def test_logger_add():
+    x = Logger()
+    len0 = len(x.data)
+    x.add('foo')
+    assert_true(len(x.data) > len0)
+    assert_true(os.path.isfile(log_file))
+
+
+def test_logger_write():
+    x = Logger()
+    x.write()
+    assert_true(os.path.isfile(log_file))

--- a/permafrost_benchmark_system/tests/test_modelingest.py
+++ b/permafrost_benchmark_system/tests/test_modelingest.py
@@ -4,7 +4,7 @@ import os
 import shutil
 from nose.tools import assert_true, assert_false, assert_equal
 from permafrost_benchmark_system.ingest import ModelIngestTool
-from . import (ingest_file, model_file, note_file, tmp_dir,
+from . import (ingest_file, model_file, log_file, tmp_dir,
                make_test_files)
 
 
@@ -15,7 +15,7 @@ def setup_module():
 
 def teardown_module():
     shutil.rmtree(tmp_dir)
-    for f in [ingest_file, model_file, note_file]:
+    for f in [ingest_file, model_file, log_file]:
         try:
             os.remove(f)
         except:
@@ -39,6 +39,11 @@ def test_init_with_ingest_file():
     assert_equal(x.ingest_files[0].name, model_file)
 
 
+def test_logger():
+    x = ModelIngestTool()
+    assert_true(os.path.isfile(log_file))
+
+
 def test_set_dest_dir():
     x = ModelIngestTool()
     x.dest_dir = tmp_dir
@@ -50,14 +55,7 @@ def test_verify():
     x.load(ingest_file)
     x.verify()
     assert_false(os.path.isfile(model_file))
-    assert_true(os.path.isfile(note_file))
-
-
-def test_leave_file_note():
-    x = ModelIngestTool()
-    msg = 'Hi there'
-    x._leave_file_note(model_file, msg)
-    assert_true(os.path.isfile(note_file))
+    assert_true(os.path.isfile(log_file))
 
 
 def test_move_file_new():
@@ -68,7 +66,7 @@ def test_move_file_new():
     x.ingest_files[0].is_verified = True
     x.move()
     assert_true(os.path.isfile(os.path.join(tmp_dir, model_file)))
-    assert_true(os.path.isfile(note_file))
+    assert_true(os.path.isfile(log_file))
 
 
 def test_move_file_exists():
@@ -79,4 +77,4 @@ def test_move_file_exists():
     x.ingest_files[0].is_verified = True
     x.move()
     assert_true(os.path.isfile(os.path.join('tmp', model_file)))
-    assert_true(os.path.isfile(note_file))
+    assert_true(os.path.isfile(log_file))

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(name='permafrost-benchmark-system',
       install_requires=[
           'pyyaml',
           'netCDF4',
+          'markdown',
           'basic-modeling-interface',
       ],
       packages=find_packages(exclude=['*.tests']),


### PR DESCRIPTION
The logger takes Markdown strings as messages and writes them to an HTML file (always `index.html`).