### PR TITLE
Place and symlink model outputs

### DIFF
--- a/.bmi/benchmark_ingest_tool/ingest.yaml.tmpl
+++ b/.bmi/benchmark_ingest_tool/ingest.yaml.tmpl
@@ -1,4 +1,6 @@
 ilamb_root: {ilamb_root}
 dest_dir: {dest_dir}
+link_dir: {link_dir}
+study_name: {study_name}
 ingest_files: {ingest_files}
 make_public: {make_public}

--- a/.bmi/benchmark_ingest_tool/parameters.yaml
+++ b/.bmi/benchmark_ingest_tool/parameters.yaml
@@ -12,6 +12,21 @@ dest_dir:
     type: string
     default: DATA
 
+link_dir:
+  description:
+    Directory relative to ILAMB_ROOT where benchmark datasets are
+    linked (optional)
+  value:
+    type: string
+    default: ''
+
+study_name:
+  description:
+    Name of modeling project or study; e.g., CMIP5 (optional)
+  value:
+    type: string
+    default: ''
+
 ingest_files:
   description:
     A list of benchmark data files to ingest

--- a/.bmi/model_ingest_tool/ingest.yaml.tmpl
+++ b/.bmi/model_ingest_tool/ingest.yaml.tmpl
@@ -1,4 +1,6 @@
 ilamb_root: {ilamb_root}
 dest_dir: {dest_dir}
+link_dir: {link_dir}
+study_name: {study_name}
 ingest_files: {ingest_files}
 make_public: {make_public}

--- a/.bmi/model_ingest_tool/parameters.yaml
+++ b/.bmi/model_ingest_tool/parameters.yaml
@@ -12,6 +12,21 @@ dest_dir:
     type: string
     default: MODELS
 
+link_dir:
+  description:
+    Directory relative to ILAMB_ROOT where model outputs are linked
+    (optional)
+  value:
+    type: string
+    default: ''
+
+study_name:
+  description:
+    Name of modeling project or study; e.g., CMIP5 (optional)
+  value:
+    type: string
+    default: ''
+
 ingest_files:
   description:
     A list of model output files to ingest

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -104,7 +104,7 @@ class ModelIngestTool(object):
             if f.is_verified:
                 target_dir = os.path.join(models_dir, f.data)
                 if not os.path.isdir(target_dir):
-                    os.mkdir(target_dir)
+                    os.makedirs(target_dir)
                 msg = file_moved.format(f.name, target_dir)
                 try:
                     shutil.move(f.name, target_dir)
@@ -136,7 +136,7 @@ class ModelIngestTool(object):
                            self.link_dir,
                            self.study_name)
         if not os.path.isdir(dst_dir):
-            os.mkdir(dst_dir)
+            os.makedirs(dst_dir)
         dst = os.path.join(dst_dir, ingest_file.name)
         os.symlink(src, dst)
 

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -47,8 +47,8 @@ class ModelIngestTool(object):
 
     """
     def __init__(self, ingest_file=None):
-        self.ilamb_root = None
-        self.dest_dir = None
+        self.ilamb_root = ''
+        self.dest_dir = ''
         self.link_dir = ''
         self.study_name = ''
         self.ingest_files = []

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -98,13 +98,6 @@ class ModelIngestTool(object):
         """
         Move ingest files to the ILAMB MODELS directory.
 
-        Notes
-        -----
-        A file that is moved is replaced with a text file listing the
-        new location of the file. If the file exists in the target
-        location, the file is replaced with a text file stating that
-        the file was not moved.
-
         """
         models_dir = os.path.join(self.ilamb_root, self.dest_dir)
         for f in self.ingest_files:

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -101,15 +101,39 @@ class ModelIngestTool(object):
         models_dir = os.path.join(self.ilamb_root, self.dest_dir)
         for f in self.ingest_files:
             if f.is_verified:
-                msg = file_moved.format(f.name, models_dir)
+                target_dir = os.path.join(models_dir, f.data)
+                if not os.path.isdir(target_dir):
+                    os.mkdir(target_dir)
+                msg = file_moved.format(f.name, target_dir)
                 try:
-                    shutil.move(f.name, models_dir)
+                    shutil.move(f.name, target_dir)
+                    self.symlink(f)
                 except:
-                    msg = file_exists.format(f.name, models_dir)
+                    msg = file_exists.format(f.name, target_dir)
                     if os.path.exists(f.name):
                         os.remove(f.name)
                 finally:
                     self.log.add(msg)
+
+    def symlink(self, ingest_file):
+        """
+        Symlink a file into the PBS project directory.
+
+        Parameters
+        ----------
+        ingest_file : IngestFile
+          File for which symlink is crated.
+
+        """
+        src = os.path.join(self.ilamb_root,
+                           self.dest_dir,
+                           ingest_file.data,
+                           ingest_file.name)
+        dst = os.path.join(self.ilamb_root,
+                           'MODELS-by-project',
+                           'PBS',
+                           ingest_file.name)
+        os.symlink(src, dst)
 
 
 class BenchmarkIngestTool(object):

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -36,6 +36,10 @@ class ModelIngestTool(object):
       Path to the ILAMB root directory.
     dest_dir : str
       Directory relative to ILAMB_ROOT where model outputs are stored.
+    link_dir : str, optional
+      Directory relative to ILAMB_ROOT where model outputs are linked.
+    study_name : str, optional
+      Name of modeling project or study; e.g., CMIP5.
     ingest_files : list
       List of files to ingest.
     make_public : bool
@@ -45,6 +49,8 @@ class ModelIngestTool(object):
     def __init__(self, ingest_file=None):
         self.ilamb_root = None
         self.dest_dir = None
+        self.link_dir = ''
+        self.study_name = ''
         self.ingest_files = []
         self.make_public = True
         self.log = Logger(title='Model Ingest Tool Summary')
@@ -65,6 +71,8 @@ class ModelIngestTool(object):
             cfg = yaml.safe_load(fp)
         self.ilamb_root = cfg['ilamb_root']
         self.dest_dir = cfg['dest_dir']
+        self.link_dir = cfg['link_dir']
+        self.study_name = cfg['study_name']
         for f in cfg['ingest_files']:
             self.ingest_files.append(IngestFile(f))
         self.make_public = cfg['make_public']
@@ -107,7 +115,8 @@ class ModelIngestTool(object):
                 msg = file_moved.format(f.name, target_dir)
                 try:
                     shutil.move(f.name, target_dir)
-                    self.symlink(f)
+                    if len(self.link_dir) > 0:
+                        self.symlink(f)
                 except:
                     msg = file_exists.format(f.name, target_dir)
                     if os.path.exists(f.name):
@@ -130,8 +139,8 @@ class ModelIngestTool(object):
                            ingest_file.data,
                            ingest_file.name)
         dst = os.path.join(self.ilamb_root,
-                           'MODELS-by-project',
-                           'PBS',
+                           self.link_dir,
+                           self.study_name,
                            ingest_file.name)
         os.symlink(src, dst)
 

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -108,12 +108,13 @@ class ModelIngestTool(object):
                 msg = file_moved.format(f.name, target_dir)
                 try:
                     shutil.move(f.name, target_dir)
-                    if len(self.link_dir) > 0:
-                        self.symlink(f)
-                except:
+                except shutil.Error:
                     msg = file_exists.format(f.name, target_dir)
                     if os.path.exists(f.name):
                         os.remove(f.name)
+                else:
+                    if len(self.link_dir) > 0:
+                        self.symlink(f)
                 finally:
                     self.log.add(msg)
 

--- a/permafrost_benchmark_system/ingest.py
+++ b/permafrost_benchmark_system/ingest.py
@@ -132,10 +132,12 @@ class ModelIngestTool(object):
                            self.dest_dir,
                            ingest_file.data,
                            ingest_file.name)
-        dst = os.path.join(self.ilamb_root,
+        dst_dir = os.path.join(self.ilamb_root,
                            self.link_dir,
-                           self.study_name,
-                           ingest_file.name)
+                           self.study_name)
+        if not os.path.isdir(dst_dir):
+            os.mkdir(dst_dir)
+        dst = os.path.join(dst_dir, ingest_file.name)
         os.symlink(src, dst)
 
 

--- a/permafrost_benchmark_system/tests/__init__.py
+++ b/permafrost_benchmark_system/tests/__init__.py
@@ -8,6 +8,8 @@ ingest_file = 'test_ingest.yaml'
 model_file = 'test_model.txt'
 log_file = 'index.html'
 tmp_dir = 'tmp'
+link_dir = 'link'
+study_name = 'PBS'
 
 
 def make_test_files():
@@ -20,6 +22,8 @@ def make_test_files():
     cfg = dict()
     cfg['ilamb_root'] = os.getcwd()
     cfg['dest_dir'] = tmp_dir
+    cfg['link_dir'] = link_dir
+    cfg['study_name'] = study_name
     cfg['ingest_files'] = [model_file]
     cfg['make_public'] = True
     with open(ingest_file, 'w') as fp:

--- a/permafrost_benchmark_system/tests/test_modelingest.py
+++ b/permafrost_benchmark_system/tests/test_modelingest.py
@@ -4,7 +4,7 @@ import os
 import shutil
 from nose.tools import assert_true, assert_false, assert_equal
 from permafrost_benchmark_system.ingest import ModelIngestTool
-from . import (ingest_file, model_file, log_file, tmp_dir,
+from . import (ingest_file, model_file, log_file, tmp_dir, link_dir,
                make_test_files)
 
 
@@ -15,6 +15,7 @@ def setup_module():
 
 def teardown_module():
     shutil.rmtree(tmp_dir)
+    shutil.rmtree(link_dir)
     for f in [ingest_file, model_file, log_file]:
         try:
             os.remove(f)
@@ -64,8 +65,9 @@ def test_move_file_new():
     x.load(ingest_file)
     # x.verify()  # verify will clobber my simple test file
     x.ingest_files[0].is_verified = True
+    x.ingest_files[0].data = 'foo'
     x.move()
-    assert_true(os.path.isfile(os.path.join(tmp_dir, model_file)))
+    assert_true(os.path.isfile(os.path.join(tmp_dir, 'foo', model_file)))
     assert_true(os.path.isfile(log_file))
 
 
@@ -75,6 +77,7 @@ def test_move_file_exists():
     x.load(ingest_file)
     # x.verify()  # verify will clobber my simple test file
     x.ingest_files[0].is_verified = True
+    x.ingest_files[0].data = 'foo'
     x.move()
-    assert_true(os.path.isfile(os.path.join('tmp', model_file)))
+    assert_true(os.path.isfile(os.path.join(tmp_dir, 'foo', model_file)))
     assert_true(os.path.isfile(log_file))


### PR DESCRIPTION
This PR modifies the MIT so that model outputs are placed in `$ILAMB_ROOT/MODELS/<model_name>` and symlinked in `$ILAMB_ROOT/MODELS-by-project/PBS`.