### PR TITLE
Allow uploaded files to be overwritten

### DIFF
--- a/.bmi/benchmark_ingest_tool/info.yaml
+++ b/.bmi/benchmark_ingest_tool/info.yaml
@@ -2,8 +2,8 @@ author: Mark Piper
 doi:
 email: mark.piper@colorado.edu
 license: Apache-2.0
-url: https://github.com/permamodel/pbs
-version: 0.1
+url: https://permamodel.github.io/pbs
+version: 1.0
 summary:
   The Permafrost Benchmark System (PBS), is a collaboration between
   researchers at NSIDC, WHOI, LANL, and CSDMS, for conducting

--- a/.bmi/benchmark_ingest_tool/ingest.yaml.tmpl
+++ b/.bmi/benchmark_ingest_tool/ingest.yaml.tmpl
@@ -2,6 +2,7 @@ ilamb_root: {ilamb_root}
 dest_dir: {dest_dir}
 link_dir: {link_dir}
 study_name: {study_name}
+group_name: {group_name}
 ingest_files: {ingest_files}
 make_public: {make_public}
 overwrite_files: {overwrite_files}

--- a/.bmi/benchmark_ingest_tool/ingest.yaml.tmpl
+++ b/.bmi/benchmark_ingest_tool/ingest.yaml.tmpl
@@ -1,7 +1,7 @@
 ilamb_root: {ilamb_root}
 dest_dir: {dest_dir}
 link_dir: {link_dir}
-study_name: {study_name}
+project_name: {project_name}
 group_name: {group_name}
 ingest_files: {ingest_files}
 make_public: {make_public}

--- a/.bmi/benchmark_ingest_tool/ingest.yaml.tmpl
+++ b/.bmi/benchmark_ingest_tool/ingest.yaml.tmpl
@@ -4,3 +4,4 @@ link_dir: {link_dir}
 study_name: {study_name}
 ingest_files: {ingest_files}
 make_public: {make_public}
+overwrite_files: {overwrite_files}

--- a/.bmi/benchmark_ingest_tool/ingest.yaml.tmpl
+++ b/.bmi/benchmark_ingest_tool/ingest.yaml.tmpl
@@ -2,7 +2,7 @@ ilamb_root: {ilamb_root}
 dest_dir: {dest_dir}
 link_dir: {link_dir}
 project_name: {project_name}
-group_name: {group_name}
+source_name: {source_name}
 ingest_files: {ingest_files}
 make_public: {make_public}
 overwrite_files: {overwrite_files}

--- a/.bmi/benchmark_ingest_tool/parameters.yaml
+++ b/.bmi/benchmark_ingest_tool/parameters.yaml
@@ -20,9 +20,9 @@ link_dir:
     type: string
     default: 'DATA-by-project'
 
-study_name:
+project_name:
   description:
-    Name of data source; e.g., FLUXNET (optional)
+    Name of modeling project or study; e.g., PBS (optional)    
   value:
     type: string
     default: 'PBS'

--- a/.bmi/benchmark_ingest_tool/parameters.yaml
+++ b/.bmi/benchmark_ingest_tool/parameters.yaml
@@ -42,3 +42,14 @@ make_public:
     choices:
       - true
       - false
+
+overwrite_files:
+  description:
+    Overwrite existing files? (Note that base ILAMB files can only be
+    modified by an administrator.)
+  value:
+    type: choice
+    default: false
+    choices:
+      - true
+      - false

--- a/.bmi/benchmark_ingest_tool/parameters.yaml
+++ b/.bmi/benchmark_ingest_tool/parameters.yaml
@@ -27,10 +27,10 @@ project_name:
     type: string
     default: 'PBS'
 
-group_name:
+source_name:
   description:
-    "A name under which the uploaded data can be grouped; e.g.,
-    your organization ('CSDMS') or your initials ('MDP') (required)"
+    "Name of source for uploaded data; e.g., your group or
+    organization ('CSDMS') or your initials ('MDP') (required)"
   value:
     type: string
     default: ''

--- a/.bmi/benchmark_ingest_tool/parameters.yaml
+++ b/.bmi/benchmark_ingest_tool/parameters.yaml
@@ -22,10 +22,18 @@ link_dir:
 
 study_name:
   description:
-    Name of modeling project or study; e.g., CMIP5 (optional)
+    Name of data source; e.g., FLUXNET (optional)
   value:
     type: string
     default: 'PBS'
+
+group_name:
+  description:
+    "A name under which the uploaded data can be grouped; e.g.,
+    your organization ('CSDMS') or your initials ('MDP') (required)"
+  value:
+    type: string
+    default: ''
 
 ingest_files:
   description:

--- a/.bmi/model_ingest_tool/info.yaml
+++ b/.bmi/model_ingest_tool/info.yaml
@@ -2,8 +2,8 @@ author: Mark Piper
 doi:
 email: mark.piper@colorado.edu
 license: Apache-2.0
-url: https://github.com/permamodel/pbs
-version: 0.1
+url: https://permamodel.github.io/pbs
+version: 1.0
 summary: 
   The Permafrost Benchmark System (PBS), is a collaboration between
   researchers at NSIDC, WHOI, LANL, and CSDMS, for conducting

--- a/.bmi/model_ingest_tool/ingest.yaml.tmpl
+++ b/.bmi/model_ingest_tool/ingest.yaml.tmpl
@@ -2,6 +2,7 @@ ilamb_root: {ilamb_root}
 dest_dir: {dest_dir}
 link_dir: {link_dir}
 study_name: {study_name}
+group_name: {group_name}
 ingest_files: {ingest_files}
 make_public: {make_public}
 overwrite_files: {overwrite_files}

--- a/.bmi/model_ingest_tool/ingest.yaml.tmpl
+++ b/.bmi/model_ingest_tool/ingest.yaml.tmpl
@@ -1,7 +1,7 @@
 ilamb_root: {ilamb_root}
 dest_dir: {dest_dir}
 link_dir: {link_dir}
-study_name: {study_name}
+project_name: {project_name}
 group_name: {group_name}
 ingest_files: {ingest_files}
 make_public: {make_public}

--- a/.bmi/model_ingest_tool/ingest.yaml.tmpl
+++ b/.bmi/model_ingest_tool/ingest.yaml.tmpl
@@ -4,3 +4,4 @@ link_dir: {link_dir}
 study_name: {study_name}
 ingest_files: {ingest_files}
 make_public: {make_public}
+overwrite_files: {overwrite_files}

--- a/.bmi/model_ingest_tool/ingest.yaml.tmpl
+++ b/.bmi/model_ingest_tool/ingest.yaml.tmpl
@@ -2,7 +2,7 @@ ilamb_root: {ilamb_root}
 dest_dir: {dest_dir}
 link_dir: {link_dir}
 project_name: {project_name}
-group_name: {group_name}
+source_name: {source_name}
 ingest_files: {ingest_files}
 make_public: {make_public}
 overwrite_files: {overwrite_files}

--- a/.bmi/model_ingest_tool/parameters.yaml
+++ b/.bmi/model_ingest_tool/parameters.yaml
@@ -42,3 +42,14 @@ make_public:
     choices:
       - true
       - false
+
+overwrite_files:
+  description:
+    Overwrite existing files? (Note that base ILAMB files can only be
+    modified by an administrator.)
+  value:
+    type: choice
+    default: false
+    choices:
+      - true
+      - false

--- a/.bmi/model_ingest_tool/parameters.yaml
+++ b/.bmi/model_ingest_tool/parameters.yaml
@@ -27,10 +27,10 @@ project_name:
     type: string
     default: 'PBS'
 
-group_name:
+source_name:
   description:
-    "A name under which the uploaded model outputs can be grouped; e.g.,
-    your organization ('CSDMS') or your initials ('MDP') (optional)"
+    "A name for grouping uploaded model outputs; e.g., your
+    organization ('CSDMS') or your initials ('MDP') (optional)"
   value:
     type: string
     default: ''

--- a/.bmi/model_ingest_tool/parameters.yaml
+++ b/.bmi/model_ingest_tool/parameters.yaml
@@ -20,7 +20,7 @@ link_dir:
     type: string
     default: 'MODELS-by-project'
 
-study_name:
+project_name:
   description:
     Name of modeling project or study; e.g., CMIP5 (optional)
   value:

--- a/.bmi/model_ingest_tool/parameters.yaml
+++ b/.bmi/model_ingest_tool/parameters.yaml
@@ -27,6 +27,14 @@ study_name:
     type: string
     default: 'PBS'
 
+group_name:
+  description:
+    "A name under which the uploaded model outputs can be grouped; e.g.,
+    your organization ('CSDMS') or your initials ('MDP') (optional)"
+  value:
+    type: string
+    default: ''
+
 ingest_files:
   description:
     A list of model output files to ingest

--- a/pbs_executor/__init__.py
+++ b/pbs_executor/__init__.py
@@ -2,7 +2,7 @@
 import os
 
 
-__version__ = '0.1'
+__version__ = '1.0'
 
 pbs_directory = os.path.dirname(__file__)
 data_directory = os.path.join(pbs_directory, 'data')

--- a/pbs_executor/data/ingest_benchmark.yaml
+++ b/pbs_executor/data/ingest_benchmark.yaml
@@ -2,5 +2,6 @@ ilamb_root: /home/csdms/ilamb
 dest_dir: DATA
 link_dir: DATA-by-project
 study_name: PBS
+group_name: CSDMS
 ingest_files: ['nep.nc']
 make_public: True

--- a/pbs_executor/data/ingest_benchmark.yaml
+++ b/pbs_executor/data/ingest_benchmark.yaml
@@ -2,6 +2,6 @@ ilamb_root: /home/csdms/ilamb
 dest_dir: DATA
 link_dir: DATA-by-project
 project_name: PBS
-group_name: CSDMS
+source_name: CSDMS
 ingest_files: ['nep.nc']
 make_public: True

--- a/pbs_executor/data/ingest_benchmark.yaml
+++ b/pbs_executor/data/ingest_benchmark.yaml
@@ -1,7 +1,7 @@
 ilamb_root: /home/csdms/ilamb
 dest_dir: DATA
 link_dir: DATA-by-project
-study_name: PBS
+project_name: PBS
 group_name: CSDMS
 ingest_files: ['nep.nc']
 make_public: True

--- a/pbs_executor/data/ingest_model.yaml
+++ b/pbs_executor/data/ingest_model.yaml
@@ -2,5 +2,6 @@ ilamb_root: /home/csdms/ilamb
 dest_dir: MODELS
 link_dir: MODELS-by-project
 study_name: PBS
+group_name:
 ingest_files: ['sftlf_fx_PBS-test_historical_r9i0p0.nc']
 make_public: True

--- a/pbs_executor/data/ingest_model.yaml
+++ b/pbs_executor/data/ingest_model.yaml
@@ -1,7 +1,7 @@
 ilamb_root: /home/csdms/ilamb
 dest_dir: MODELS
 link_dir: MODELS-by-project
-study_name: PBS
+project_name: PBS
 group_name:
 ingest_files: ['sftlf_fx_PBS-test_historical_r9i0p0.nc']
 make_public: True

--- a/pbs_executor/data/ingest_model.yaml
+++ b/pbs_executor/data/ingest_model.yaml
@@ -2,6 +2,6 @@ ilamb_root: /home/csdms/ilamb
 dest_dir: MODELS
 link_dir: MODELS-by-project
 project_name: PBS
-group_name:
+source_name:
 ingest_files: ['sftlf_fx_PBS-test_historical_r9i0p0.nc']
 make_public: True

--- a/pbs_executor/ingest.py
+++ b/pbs_executor/ingest.py
@@ -213,14 +213,21 @@ class BenchmarkIngestTool(IngestTool):
         data_dir = os.path.join(self.ilamb_root, self.dest_dir)
         for f in self.ingest_files:
             if f.is_verified:
-                target_dir = os.path.join(data_dir, f.data, self.study_name)
+                target = target_dir = os.path.join(data_dir, f.data,
+                                                   self.group_name)
                 if not os.path.isdir(target_dir):
                     os.makedirs(target_dir, mode=0775)
-                msg = file_moved.format(f.name, target_dir)
+                if self.overwrite_files:
+                    target = os.path.join(target_dir, f.name)
+                msg = file_moved.format(f.name, target)
                 try:
-                    shutil.move(f.name, target_dir)
+                    shutil.move(f.name, target)
+                except IOError:
+                    msg = file_protected.format(target)
+                    if os.path.exists(f.name):
+                        os.remove(f.name)
                 except shutil.Error:
-                    msg = file_exists.format(f.name, target_dir)
+                    msg = file_exists.format(f.name, target)
                     if os.path.exists(f.name):
                         os.remove(f.name)
                 else:

--- a/pbs_executor/ingest.py
+++ b/pbs_executor/ingest.py
@@ -47,6 +47,9 @@ class IngestTool(object):
       List of files to ingest.
     make_public : bool
       Set to True to allow others to see and use ingested files.
+    overwrite_files : bool
+      Set to True to allow users to overwrite uploaded files. Only an
+      administrator can overwrite files distributed with ILAMB.
 
     """
     def __init__(self, ingest_file=None):
@@ -56,6 +59,7 @@ class IngestTool(object):
         self.study_name = ''
         self.ingest_files = []
         self.make_public = True
+        self.overwrite_files = False
 
     def load(self, ingest_file):
         """
@@ -76,6 +80,7 @@ class IngestTool(object):
         for f in cfg['ingest_files']:
             self.ingest_files.append(IngestFile(f))
         self.make_public = cfg['make_public']
+        self.overwrite_files = cfg['overwrite_files']
 
     def symlink(self, ingest_file, use_study_name=False):
         """

--- a/pbs_executor/ingest.py
+++ b/pbs_executor/ingest.py
@@ -85,6 +85,8 @@ class IngestTool(object):
         ----------
         ingest_file : IngestFile
           File for which symlink is crated.
+        use_study_name : bool, optional
+          Set to True to append study name to path (default is False).
 
         """
         src = os.path.join(self.ilamb_root, self.dest_dir,

--- a/pbs_executor/ingest.py
+++ b/pbs_executor/ingest.py
@@ -48,7 +48,7 @@ class IngestTool(object):
       Directory relative to ILAMB_ROOT where ingested files are linked.
     project_name : str, optional
       Name of modeling project or study; e.g., CMIP5, MsTMIP, PBS.
-    group_name : str
+    source_name : str
       A name under which uploaded files can be grouped. Required for 
       grouping uploaded benchmark datasets.
     ingest_files : list
@@ -65,7 +65,7 @@ class IngestTool(object):
         self.dest_dir = ''
         self.link_dir = ''
         self.project_name = ''
-        self.group_name = ''
+        self.source_name = ''
         self.ingest_files = []
         self.make_public = True
         self.overwrite_files = False
@@ -86,14 +86,14 @@ class IngestTool(object):
         self.dest_dir = cfg['dest_dir']
         self.link_dir = cfg['link_dir']
         self.project_name = cfg['project_name']
-        self.group_name = cfg['group_name']
+        self.source_name = cfg['source_name']
         for f in cfg['ingest_files']:
             self.ingest_files.append(IngestFile(f))
         self.make_public = cfg['make_public']
         self.overwrite_files = cfg['overwrite_files']
 
 
-    def symlink(self, src_dir, ingest_file, append_group_name=False):
+    def symlink(self, src_dir, ingest_file, append_source_name=False):
         """
         Symlink a file into the PBS project directory.
 
@@ -103,7 +103,7 @@ class IngestTool(object):
           The directory path that contains the source file to link.
         ingest_file : IngestFile
           File for which symlink is crated.
-        append_group_name : bool, optional
+        append_source_name : bool, optional
           Set to True to append group name to path (default is False).
 
         """
@@ -113,8 +113,8 @@ class IngestTool(object):
         if not os.path.isdir(dst_dir):
             os.makedirs(dst_dir)
         dst_filename = ingest_file.name
-        if append_group_name:
-            dst_filename += '.' + self.group_name
+        if append_source_name:
+            dst_filename += '.' + self.source_name
         dst = os.path.join(dst_dir, dst_filename)
         if os.path.islink(dst):
             os.remove(dst)
@@ -217,7 +217,7 @@ class BenchmarkIngestTool(IngestTool):
         for f in self.ingest_files:
             if f.is_verified:
                 target = target_dir = os.path.join(data_dir, f.data,
-                                                   self.group_name)
+                                                   self.source_name)
                 if not os.path.isdir(target_dir):
                     os.makedirs(target_dir, mode=0775)
                 if self.overwrite_files:
@@ -235,6 +235,6 @@ class BenchmarkIngestTool(IngestTool):
                         os.remove(f.name)
                 else:
                     if len(self.link_dir) > 0:
-                        self.symlink(target_dir, f, append_group_name=True)
+                        self.symlink(target_dir, f, append_source_name=True)
                 finally:
                     self.log.add(msg)

--- a/pbs_executor/ingest.py
+++ b/pbs_executor/ingest.py
@@ -151,7 +151,7 @@ class ModelIngestTool(IngestTool):
                 target = target_dir = os.path.join(models_dir, f.data)
                 if not os.path.isdir(target_dir):
                     os.makedirs(target_dir)
-                if self.overwrite:
+                if self.overwrite_files:
                     target = os.path.join(target_dir, f.name)
                 msg = file_moved.format(f.name, target)
                 try:

--- a/pbs_executor/ingest.py
+++ b/pbs_executor/ingest.py
@@ -109,7 +109,8 @@ class IngestTool(object):
         if not os.path.isdir(dst_dir):
             os.makedirs(dst_dir)
         dst = os.path.join(dst_dir, ingest_file.name)
-        os.symlink(src, dst)
+        if not os.path.exists(dst):
+            os.symlink(src, dst)
 
 
 class ModelIngestTool(IngestTool):

--- a/pbs_executor/ingest.py
+++ b/pbs_executor/ingest.py
@@ -15,7 +15,7 @@ The file `{1}/{0}` already exists in the PBS data store.
 The file has not been updated.
 '''
 file_protected = '''## File Protected\n
-The file `{1}/{0}` is protected in the PBS data store.
+The file `{}` is protected in the PBS data store.
 The base files provided by ILAMB may only be modified by an administrator.
 The file has not been updated.
 '''
@@ -158,7 +158,7 @@ class ModelIngestTool(IngestTool):
                 try:
                     shutil.move(f.name, target)
                 except IOError:
-                    msg = file_protected.format(f.name, target)
+                    msg = file_protected.format(target)
                     if os.path.exists(f.name):
                         os.remove(f.name)
                 except shutil.Error:

--- a/pbs_executor/ingest.py
+++ b/pbs_executor/ingest.py
@@ -46,7 +46,7 @@ class IngestTool(object):
       Directory relative to ILAMB_ROOT where ingested files are stored.
     link_dir : str, optional
       Directory relative to ILAMB_ROOT where ingested files are linked.
-    study_name : str, optional
+    project_name : str, optional
       Name of modeling project or study; e.g., CMIP5, MsTMIP, PBS.
     group_name : str
       A name under which uploaded files can be grouped. Required for 
@@ -64,7 +64,7 @@ class IngestTool(object):
         self.ilamb_root = ''
         self.dest_dir = ''
         self.link_dir = ''
-        self.study_name = ''
+        self.project_name = ''
         self.group_name = ''
         self.ingest_files = []
         self.make_public = True
@@ -85,7 +85,7 @@ class IngestTool(object):
         self.ilamb_root = cfg['ilamb_root']
         self.dest_dir = cfg['dest_dir']
         self.link_dir = cfg['link_dir']
-        self.study_name = cfg['study_name']
+        self.project_name = cfg['project_name']
         self.group_name = cfg['group_name']
         for f in cfg['ingest_files']:
             self.ingest_files.append(IngestFile(f))
@@ -109,7 +109,7 @@ class IngestTool(object):
         """
         src = os.path.join(src_dir, ingest_file.name)
         dst_dir = os.path.join(self.ilamb_root, self.link_dir,
-                               self.study_name)
+                               self.project_name)
         if not os.path.isdir(dst_dir):
             os.makedirs(dst_dir)
         dst_filename = ingest_file.name

--- a/pbs_executor/ingest.py
+++ b/pbs_executor/ingest.py
@@ -92,30 +92,33 @@ class IngestTool(object):
         self.make_public = cfg['make_public']
         self.overwrite_files = cfg['overwrite_files']
 
-    def symlink(self, ingest_file, use_study_name=False):
+
+    def symlink(self, src_dir, ingest_file, append_group_name=False):
         """
         Symlink a file into the PBS project directory.
 
         Parameters
         ----------
+        src_dir : str
+          The directory path that contains the source file to link.
         ingest_file : IngestFile
           File for which symlink is crated.
-        use_study_name : bool, optional
-          Set to True to append study name to path (default is False).
+        append_group_name : bool, optional
+          Set to True to append group name to path (default is False).
 
         """
-        src = os.path.join(self.ilamb_root, self.dest_dir,
-                           ingest_file.data)
-        if use_study_name:
-            src = os.path.join(src, self.study_name)
-        src = os.path.join(src, ingest_file.name)
+        src = os.path.join(src_dir, ingest_file.name)
         dst_dir = os.path.join(self.ilamb_root, self.link_dir,
                                self.study_name)
         if not os.path.isdir(dst_dir):
             os.makedirs(dst_dir)
-        dst = os.path.join(dst_dir, ingest_file.name)
-        if not os.path.exists(dst):
-            os.symlink(src, dst)
+        dst_filename = ingest_file.name
+        if append_group_name:
+            dst_filename += '.' + self.group_name
+        dst = os.path.join(dst_dir, dst_filename)
+        if os.path.islink(dst):
+            os.remove(dst)
+        os.symlink(src, dst)
 
 
 class ModelIngestTool(IngestTool):
@@ -172,7 +175,7 @@ class ModelIngestTool(IngestTool):
                         os.remove(f.name)
                 else:
                     if len(self.link_dir) > 0:
-                        self.symlink(f)
+                        self.symlink(target_dir, f)
                 finally:
                     self.log.add(msg)
 
@@ -232,6 +235,6 @@ class BenchmarkIngestTool(IngestTool):
                         os.remove(f.name)
                 else:
                     if len(self.link_dir) > 0:
-                        self.symlink(f, use_study_name=True)
+                        self.symlink(target_dir, f, append_group_name=True)
                 finally:
                     self.log.add(msg)

--- a/pbs_executor/ingest.py
+++ b/pbs_executor/ingest.py
@@ -48,6 +48,9 @@ class IngestTool(object):
       Directory relative to ILAMB_ROOT where ingested files are linked.
     study_name : str, optional
       Name of modeling project or study; e.g., CMIP5, MsTMIP, PBS.
+    group_name : str
+      A name under which uploaded files can be grouped. Required for 
+      grouping uploaded benchmark datasets.
     ingest_files : list
       List of files to ingest.
     make_public : bool
@@ -62,6 +65,7 @@ class IngestTool(object):
         self.dest_dir = ''
         self.link_dir = ''
         self.study_name = ''
+        self.group_name = ''
         self.ingest_files = []
         self.make_public = True
         self.overwrite_files = False
@@ -82,6 +86,7 @@ class IngestTool(object):
         self.dest_dir = cfg['dest_dir']
         self.link_dir = cfg['link_dir']
         self.study_name = cfg['study_name']
+        self.group_name = cfg['group_name']
         for f in cfg['ingest_files']:
             self.ingest_files.append(IngestFile(f))
         self.make_public = cfg['make_public']

--- a/pbs_executor/tests/__init__.py
+++ b/pbs_executor/tests/__init__.py
@@ -21,6 +21,7 @@ def make_files(upload_file):
     cfg['study_name'] = study_name
     cfg['ingest_files'] = [upload_file]
     cfg['make_public'] = True
+    cfg['overwrite_files'] = False
     with open(ingest_file, 'w') as fp:
         yaml.safe_dump(cfg, fp, default_flow_style=False)
 

--- a/pbs_executor/tests/__init__.py
+++ b/pbs_executor/tests/__init__.py
@@ -14,6 +14,7 @@ data_dir = 'DATA'
 models_link_dir = 'MODELS-link'
 data_link_dir = 'DATA-link'
 study_name = 'PBS'
+group_name = 'CSDMS'
 
 
 def make_files(upload_file, dest_dir, link_dir):
@@ -22,6 +23,7 @@ def make_files(upload_file, dest_dir, link_dir):
     cfg['dest_dir'] = dest_dir
     cfg['link_dir'] = link_dir
     cfg['study_name'] = study_name
+    cfg['group_name'] = group_name
     cfg['ingest_files'] = [upload_file]
     cfg['make_public'] = True
     cfg['overwrite_files'] = False

--- a/pbs_executor/tests/__init__.py
+++ b/pbs_executor/tests/__init__.py
@@ -8,15 +8,17 @@ ingest_file = 'test_ingest.yaml'
 model_file = 'test_model.txt'
 benchmark_file = 'test_benchmark.txt'
 log_file = 'index.html'
-tmp_dir = 'tmp'
-link_dir = 'link'
+models_dir = 'MODELS'
+data_dir = 'DATA'
+models_link_dir = 'MODELS-link'
+data_link_dir = 'DATA-link'
 study_name = 'PBS'
 
 
-def make_files(upload_file):
+def make_files(upload_file, dest_dir, link_dir):
     cfg = dict()
     cfg['ilamb_root'] = os.getcwd()
-    cfg['dest_dir'] = tmp_dir
+    cfg['dest_dir'] = dest_dir
     cfg['link_dir'] = link_dir
     cfg['study_name'] = study_name
     cfg['ingest_files'] = [upload_file]
@@ -29,10 +31,10 @@ def make_files(upload_file):
 def make_model_files():
     with open(model_file, 'w') as fp:
         fp.write('This is a test model output file.\n')
-    make_files(model_file)
+    make_files(model_file, models_dir, models_link_dir)
 
 
 def make_benchmark_files():
     with open(benchmark_file, 'w') as fp:
         fp.write('This is a test benchmark data file.\n')
-    make_files(benchmark_file)
+    make_files(benchmark_file, data_dir, data_link_dir)

--- a/pbs_executor/tests/__init__.py
+++ b/pbs_executor/tests/__init__.py
@@ -14,7 +14,7 @@ data_dir = 'DATA'
 models_link_dir = 'MODELS-link'
 data_link_dir = 'DATA-link'
 project_name = 'PBS'
-group_name = 'CSDMS'
+source_name = 'CSDMS'
 
 
 def make_files(upload_file, dest_dir, link_dir):
@@ -23,7 +23,7 @@ def make_files(upload_file, dest_dir, link_dir):
     cfg['dest_dir'] = dest_dir
     cfg['link_dir'] = link_dir
     cfg['project_name'] = project_name
-    cfg['group_name'] = group_name
+    cfg['source_name'] = source_name
     cfg['ingest_files'] = [upload_file]
     cfg['make_public'] = True
     cfg['overwrite_files'] = False

--- a/pbs_executor/tests/__init__.py
+++ b/pbs_executor/tests/__init__.py
@@ -1,6 +1,7 @@
 """Unit tests for the pbs_executor package."""
 
 import os
+import re
 import yaml
 
 
@@ -38,3 +39,11 @@ def make_benchmark_files():
     with open(benchmark_file, 'w') as fp:
         fp.write('This is a test benchmark data file.\n')
     make_files(benchmark_file, data_dir, data_link_dir)
+
+
+def find_in_file(filename, search_str):
+    with open(filename, 'r') as fp:
+        for line in fp:
+            if re.search(search_str, line):
+                return True
+    return False

--- a/pbs_executor/tests/__init__.py
+++ b/pbs_executor/tests/__init__.py
@@ -13,7 +13,7 @@ models_dir = 'MODELS'
 data_dir = 'DATA'
 models_link_dir = 'MODELS-link'
 data_link_dir = 'DATA-link'
-study_name = 'PBS'
+project_name = 'PBS'
 group_name = 'CSDMS'
 
 
@@ -22,7 +22,7 @@ def make_files(upload_file, dest_dir, link_dir):
     cfg['ilamb_root'] = os.getcwd()
     cfg['dest_dir'] = dest_dir
     cfg['link_dir'] = link_dir
-    cfg['study_name'] = study_name
+    cfg['project_name'] = project_name
     cfg['group_name'] = group_name
     cfg['ingest_files'] = [upload_file]
     cfg['make_public'] = True

--- a/pbs_executor/tests/test_benchmarkingest.py
+++ b/pbs_executor/tests/test_benchmarkingest.py
@@ -4,19 +4,22 @@ import os
 import shutil
 from nose.tools import assert_true, assert_false, assert_equal
 from pbs_executor.ingest import BenchmarkIngestTool
-from . import (ingest_file, benchmark_file, log_file, tmp_dir,
-               link_dir, make_benchmark_files)
+from . import (ingest_file, benchmark_file, log_file, data_dir,
+               data_link_dir, make_benchmark_files)
+
+
+variable_name = 'lai'
 
 
 def setup_module():
     make_benchmark_files()
-    os.mkdir(tmp_dir)
+    os.mkdir(data_dir)
 
 
 def teardown_module():
-    shutil.rmtree(tmp_dir)
-    if os.path.exists(link_dir):
-        shutil.rmtree(link_dir)
+    shutil.rmtree(data_dir)
+    if os.path.exists(data_link_dir):
+        shutil.rmtree(data_link_dir)
     for f in [ingest_file, benchmark_file, log_file]:
         try:
             os.remove(f)
@@ -48,14 +51,14 @@ def test_logger():
 
 def test_set_dest_dir():
     x = BenchmarkIngestTool()
-    x.dest_dir = tmp_dir
-    assert_equal(x.dest_dir, tmp_dir)
+    x.dest_dir = data_dir
+    assert_equal(x.dest_dir, data_dir)
 
 
 def test_set_link_dir():
     x = BenchmarkIngestTool()
-    x.link_dir = link_dir
-    assert_equal(x.link_dir, link_dir)
+    x.link_dir = data_link_dir
+    assert_equal(x.link_dir, data_link_dir)
 
 
 def test_verify():
@@ -73,13 +76,13 @@ def test_move_file_new():
     # x.verify()  # verify will clobber my simple test file
     f = x.ingest_files[0]
     f.is_verified = True
-    f.data = 'foo'
+    f.data = variable_name
     x.move()
-    assert_true(os.path.isfile(os.path.join(tmp_dir,
+    assert_true(os.path.isfile(os.path.join(data_dir,
                                             f.data,
                                             x.study_name,
                                             f.name)))
-    assert_true(os.path.islink(os.path.join(link_dir,
+    assert_true(os.path.islink(os.path.join(data_link_dir,
                                             x.study_name,
                                             f.name)))
     assert_true(os.path.isfile(log_file))
@@ -92,13 +95,13 @@ def test_move_file_exists():
     # x.verify()  # verify will clobber my simple test file
     f = x.ingest_files[0]
     f.is_verified = True
-    f.data = 'foo'
+    f.data = variable_name
     x.move()
-    assert_true(os.path.isfile(os.path.join(tmp_dir,
+    assert_true(os.path.isfile(os.path.join(data_dir,
                                             f.data,
                                             x.study_name,
                                             f.name)))
-    assert_true(os.path.islink(os.path.join(link_dir,
+    assert_true(os.path.islink(os.path.join(data_link_dir,
                                             x.study_name,
                                             f.name)))
     assert_true(os.path.isfile(log_file))

--- a/pbs_executor/tests/test_benchmarkingest.py
+++ b/pbs_executor/tests/test_benchmarkingest.py
@@ -82,9 +82,10 @@ def test_move_file_new():
                                             f.data,
                                             x.group_name,
                                             f.name)))
+    link_name = '{}.{}'.format(f.name, x.group_name)
     assert_true(os.path.islink(os.path.join(data_link_dir,
                                             x.study_name,
-                                            f.name)))
+                                            link_name)))
     assert_true(os.path.isfile(log_file))
 
 
@@ -101,9 +102,10 @@ def test_move_file_exists():
                                             f.data,
                                             x.group_name,
                                             f.name)))
+    link_name = '{}.{}'.format(f.name, x.group_name)
     assert_true(os.path.islink(os.path.join(data_link_dir,
                                             x.study_name,
-                                            f.name)))
+                                            link_name)))
     assert_true(os.path.isfile(log_file))
     assert_true(find_in_file(log_file, 'File Exists'))
 
@@ -122,8 +124,9 @@ def test_move_file_exists_overwrite():
                                             f.data,
                                             x.group_name,
                                             f.name)))
+    link_name = '{}.{}'.format(f.name, x.group_name)
     assert_true(os.path.islink(os.path.join(data_link_dir,
                                             x.study_name,
-                                            f.name)))
+                                            link_name)))
     assert_true(os.path.isfile(log_file))
     assert_false(find_in_file(log_file, 'File Exists'))

--- a/pbs_executor/tests/test_benchmarkingest.py
+++ b/pbs_executor/tests/test_benchmarkingest.py
@@ -84,7 +84,7 @@ def test_move_file_new():
                                             f.name)))
     link_name = '{}.{}'.format(f.name, x.group_name)
     assert_true(os.path.islink(os.path.join(data_link_dir,
-                                            x.study_name,
+                                            x.project_name,
                                             link_name)))
     assert_true(os.path.isfile(log_file))
 
@@ -104,7 +104,7 @@ def test_move_file_exists():
                                             f.name)))
     link_name = '{}.{}'.format(f.name, x.group_name)
     assert_true(os.path.islink(os.path.join(data_link_dir,
-                                            x.study_name,
+                                            x.project_name,
                                             link_name)))
     assert_true(os.path.isfile(log_file))
     assert_true(find_in_file(log_file, 'File Exists'))
@@ -126,7 +126,7 @@ def test_move_file_exists_overwrite():
                                             f.name)))
     link_name = '{}.{}'.format(f.name, x.group_name)
     assert_true(os.path.islink(os.path.join(data_link_dir,
-                                            x.study_name,
+                                            x.project_name,
                                             link_name)))
     assert_true(os.path.isfile(log_file))
     assert_false(find_in_file(log_file, 'File Exists'))

--- a/pbs_executor/tests/test_benchmarkingest.py
+++ b/pbs_executor/tests/test_benchmarkingest.py
@@ -80,9 +80,9 @@ def test_move_file_new():
     x.move()
     assert_true(os.path.isfile(os.path.join(data_dir,
                                             f.data,
-                                            x.group_name,
+                                            x.source_name,
                                             f.name)))
-    link_name = '{}.{}'.format(f.name, x.group_name)
+    link_name = '{}.{}'.format(f.name, x.source_name)
     assert_true(os.path.islink(os.path.join(data_link_dir,
                                             x.project_name,
                                             link_name)))
@@ -100,9 +100,9 @@ def test_move_file_exists():
     x.move()
     assert_true(os.path.isfile(os.path.join(data_dir,
                                             f.data,
-                                            x.group_name,
+                                            x.source_name,
                                             f.name)))
-    link_name = '{}.{}'.format(f.name, x.group_name)
+    link_name = '{}.{}'.format(f.name, x.source_name)
     assert_true(os.path.islink(os.path.join(data_link_dir,
                                             x.project_name,
                                             link_name)))
@@ -122,9 +122,9 @@ def test_move_file_exists_overwrite():
     x.move()
     assert_true(os.path.isfile(os.path.join(data_dir,
                                             f.data,
-                                            x.group_name,
+                                            x.source_name,
                                             f.name)))
-    link_name = '{}.{}'.format(f.name, x.group_name)
+    link_name = '{}.{}'.format(f.name, x.source_name)
     assert_true(os.path.islink(os.path.join(data_link_dir,
                                             x.project_name,
                                             link_name)))

--- a/pbs_executor/tests/test_benchmarkingest.py
+++ b/pbs_executor/tests/test_benchmarkingest.py
@@ -5,7 +5,7 @@ import shutil
 from nose.tools import assert_true, assert_false, assert_equal
 from pbs_executor.ingest import BenchmarkIngestTool
 from . import (ingest_file, benchmark_file, log_file, data_dir,
-               data_link_dir, make_benchmark_files)
+               data_link_dir, make_benchmark_files, find_in_file)
 
 
 variable_name = 'lai'
@@ -80,7 +80,7 @@ def test_move_file_new():
     x.move()
     assert_true(os.path.isfile(os.path.join(data_dir,
                                             f.data,
-                                            x.study_name,
+                                            x.group_name,
                                             f.name)))
     assert_true(os.path.islink(os.path.join(data_link_dir,
                                             x.study_name,
@@ -99,9 +99,31 @@ def test_move_file_exists():
     x.move()
     assert_true(os.path.isfile(os.path.join(data_dir,
                                             f.data,
-                                            x.study_name,
+                                            x.group_name,
                                             f.name)))
     assert_true(os.path.islink(os.path.join(data_link_dir,
                                             x.study_name,
                                             f.name)))
     assert_true(os.path.isfile(log_file))
+    assert_true(find_in_file(log_file, 'File Exists'))
+
+
+def test_move_file_exists_overwrite():
+    make_benchmark_files()
+    x = BenchmarkIngestTool()
+    x.load(ingest_file)
+    x.overwrite_files = True
+    # x.verify()  # verify will clobber my simple test file
+    f = x.ingest_files[0]
+    f.is_verified = True
+    f.data = variable_name
+    x.move()
+    assert_true(os.path.isfile(os.path.join(data_dir,
+                                            f.data,
+                                            x.group_name,
+                                            f.name)))
+    assert_true(os.path.islink(os.path.join(data_link_dir,
+                                            x.study_name,
+                                            f.name)))
+    assert_true(os.path.isfile(log_file))
+    assert_false(find_in_file(log_file, 'File Exists'))

--- a/pbs_executor/tests/test_bmimodelingesttool.py
+++ b/pbs_executor/tests/test_bmimodelingesttool.py
@@ -4,17 +4,17 @@ import os
 import shutil
 from nose.tools import raises, assert_true, assert_equal, assert_is_none
 from pbs_executor.bmi_ingest import BmiModelIngestTool
-from . import (ingest_file, model_file, log_file, tmp_dir,
+from . import (ingest_file, model_file, log_file, models_dir,
                make_model_files)
 
 
 def setup_module():
     make_model_files()
-    os.mkdir(tmp_dir)
+    os.mkdir(models_dir)
 
 
 def teardown_module():
-    shutil.rmtree(tmp_dir)
+    shutil.rmtree(models_dir)
     for f in [ingest_file, model_file, log_file]:
         try:
             os.remove(f)

--- a/pbs_executor/tests/test_modelingest.py
+++ b/pbs_executor/tests/test_modelingest.py
@@ -5,7 +5,7 @@ import shutil
 from nose.tools import assert_true, assert_false, assert_equal
 from pbs_executor.ingest import ModelIngestTool
 from . import (ingest_file, model_file, log_file, models_dir,
-               models_link_dir, make_model_files)
+               models_link_dir, make_model_files, find_in_file)
 
 
 model_name = 'SiBCASA'
@@ -73,9 +73,13 @@ def test_move_file_new():
     f.data = model_name
     x.move()
     assert_true(os.path.isfile(os.path.join(models_dir, f.data, f.name)))
+    assert_true(os.path.islink(os.path.join(models_link_dir,
+                                            x.study_name, f.name)))
     assert_true(os.path.isfile(log_file))
 
 
+# Note that an exception isn't raised, but a message is written to the
+# log file.
 def test_move_file_exists():
     make_model_files()
     x = ModelIngestTool()
@@ -86,4 +90,7 @@ def test_move_file_exists():
     f.data = model_name
     x.move()
     assert_true(os.path.isfile(os.path.join(models_dir, f.data, f.name)))
+    assert_true(os.path.islink(os.path.join(models_link_dir,
+                                            x.study_name, f.name)))
     assert_true(os.path.isfile(log_file))
+    assert_true(find_in_file(log_file, 'File Exists'))

--- a/pbs_executor/tests/test_modelingest.py
+++ b/pbs_executor/tests/test_modelingest.py
@@ -74,7 +74,7 @@ def test_move_file_new():
     x.move()
     assert_true(os.path.isfile(os.path.join(models_dir, f.data, f.name)))
     assert_true(os.path.islink(os.path.join(models_link_dir,
-                                            x.study_name, f.name)))
+                                            x.project_name, f.name)))
     assert_true(os.path.isfile(log_file))
 
 
@@ -91,7 +91,7 @@ def test_move_file_exists():
     x.move()
     assert_true(os.path.isfile(os.path.join(models_dir, f.data, f.name)))
     assert_true(os.path.islink(os.path.join(models_link_dir,
-                                            x.study_name, f.name)))
+                                            x.project_name, f.name)))
     assert_true(os.path.isfile(log_file))
     assert_true(find_in_file(log_file, 'File Exists'))
 
@@ -108,6 +108,6 @@ def test_move_file_exists_overwrite():
     x.move()
     assert_true(os.path.isfile(os.path.join(models_dir, f.data, f.name)))
     assert_true(os.path.islink(os.path.join(models_link_dir,
-                                            x.study_name, f.name)))
+                                            x.project_name, f.name)))
     assert_true(os.path.isfile(log_file))
     assert_false(find_in_file(log_file, 'File Exists'))

--- a/pbs_executor/tests/test_modelingest.py
+++ b/pbs_executor/tests/test_modelingest.py
@@ -94,3 +94,20 @@ def test_move_file_exists():
                                             x.study_name, f.name)))
     assert_true(os.path.isfile(log_file))
     assert_true(find_in_file(log_file, 'File Exists'))
+
+
+def test_move_file_exists_overwrite():
+    make_model_files()
+    x = ModelIngestTool()
+    x.load(ingest_file)
+    x.overwrite_files = True
+    # x.verify()  # verify will clobber my simple test file
+    f = x.ingest_files[0]
+    f.is_verified = True
+    f.data = model_name
+    x.move()
+    assert_true(os.path.isfile(os.path.join(models_dir, f.data, f.name)))
+    assert_true(os.path.islink(os.path.join(models_link_dir,
+                                            x.study_name, f.name)))
+    assert_true(os.path.isfile(log_file))
+    assert_false(find_in_file(log_file, 'File Exists'))

--- a/pbs_executor/tests/test_modelingest.py
+++ b/pbs_executor/tests/test_modelingest.py
@@ -4,19 +4,22 @@ import os
 import shutil
 from nose.tools import assert_true, assert_false, assert_equal
 from pbs_executor.ingest import ModelIngestTool
-from . import (ingest_file, model_file, log_file, tmp_dir, link_dir,
-               make_model_files)
+from . import (ingest_file, model_file, log_file, models_dir,
+               models_link_dir, make_model_files)
+
+
+model_name = 'SiBCASA'
 
 
 def setup_module():
     make_model_files()
-    os.mkdir(tmp_dir)
+    os.mkdir(models_dir)
 
 
 def teardown_module():
-    shutil.rmtree(tmp_dir)
-    if os.path.exists(link_dir):
-        shutil.rmtree(link_dir)
+    shutil.rmtree(models_dir)
+    if os.path.exists(models_link_dir):
+        shutil.rmtree(models_link_dir)
     for f in [ingest_file, model_file, log_file]:
         try:
             os.remove(f)
@@ -48,8 +51,8 @@ def test_logger():
 
 def test_set_dest_dir():
     x = ModelIngestTool()
-    x.dest_dir = tmp_dir
-    assert_equal(x.dest_dir, tmp_dir)
+    x.dest_dir = models_dir
+    assert_equal(x.dest_dir, models_dir)
 
 
 def test_verify():
@@ -67,9 +70,9 @@ def test_move_file_new():
     # x.verify()  # verify will clobber my simple test file
     f = x.ingest_files[0]
     f.is_verified = True
-    f.data = 'foo'
+    f.data = model_name
     x.move()
-    assert_true(os.path.isfile(os.path.join(tmp_dir, f.data, f.name)))
+    assert_true(os.path.isfile(os.path.join(models_dir, f.data, f.name)))
     assert_true(os.path.isfile(log_file))
 
 
@@ -80,7 +83,7 @@ def test_move_file_exists():
     # x.verify()  # verify will clobber my simple test file
     f = x.ingest_files[0]
     f.is_verified = True
-    f.data = 'foo'
+    f.data = model_name
     x.move()
-    assert_true(os.path.isfile(os.path.join(tmp_dir, f.data, f.name)))
+    assert_true(os.path.isfile(os.path.join(models_dir, f.data, f.name)))
     assert_true(os.path.isfile(log_file))

--- a/pbs_executor/verify.py
+++ b/pbs_executor/verify.py
@@ -202,7 +202,7 @@ class BenchmarkVerificationTool(VerificationTool):
     .. code-block:: bash
 
        filename = <variable-name>.nc
-       filename = <variable-name>_<lon-resolution>_<lat-resolution>.nc
+       filename = <variable-name>_<lon-resolution>x<lat-resolution>.nc
 
     The first is for point data, the second for gridded data.
 


### PR DESCRIPTION
Kevin made the point that if he's working on a benchmark dataset, he'd like to be able to replace the old version he'd previously uploaded to the PBS. It took a surprising amount of refactoring to make this change. I also addressed some other issues, as well; see the commit log.

This PR brings the PBS up to v1.0 release status.