### PR TITLE
Find broken nose option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,12 @@ install:
   - python setup.py install
 
 script:
-  - nosetests
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      nosetests --with-coverage --cover-package=pbs_executor
+    else
+      nosetests --with-doctest --with-coverage --cover-package=pbs_executor
+    fi
 
 after_success:
   - coveralls --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda install python=$TRAVIS_PYTHON_VERSION
-  - conda install nose pyyaml netcdf4 markdown
-  - pip install coveralls basic-modeling-interface
+  - conda install nose pyyaml netcdf4 markdown coveralls basic-modeling-interface -c csdms-stack
 
 install:
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - python setup.py install
 
 script:
-  - nosetests --with-doctest --with-coverage --cover-package=pbs_executor
+  - nosetests
 
 after_success:
   - coveralls --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
     - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda2-latest"
     - TRAVIS_PYTHON_VERSION="2.7"
 
-sudo: false
-
 before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -24,6 +22,7 @@ before_install:
   - export PATH="$CONDA_PREFIX/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
+  - source activate root
   - conda install python=$TRAVIS_PYTHON_VERSION
   - conda install nose pyyaml netcdf4 markdown coveralls basic-modeling-interface -c csdms-stack
 


### PR DESCRIPTION
This PR removes the `--with-doctest` flag from `nosetests` when building on macOS on Travis CI. This had been causing a segfault! I've also made some other small improvements to the Travis file:

* activated the root conda environment
* got all dependent packages from conda
* removed the obsolete `sudo: false` command

This is also the best PR title I've created to date.